### PR TITLE
Edge indexing fix for population splits

### DIFF
--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -284,7 +284,14 @@ def _write_edges(
                     dst_mapping=id_mapping[dst_node_pop],
                     h5_read_chunk_size=h5_read_chunk_size,
                 )
-                edge_count, sgid_count, tgid_count = _get_node_counts(h5out, edge_pop_name)
+                ### edge_count, sgid_count, tgid_count = _get_node_counts(h5out, edge_pop_name)  ### ERROR ###
+                # Note: _get_node_counts() returns the node counts based on the node indices that are actually present
+                #       in the edge table. However, in case of unconnected nodes this count may be too low, leading
+                #       to a wrong computation of the index vectors in _write_indexes() which should always have the
+                #       same length as the number of nodes, no matter whether or not they are connected!!
+                edge_count, _, _ = _get_node_counts(h5out, edge_pop_name)  ### FIX ###
+                sgid_count = id_mapping[src_node_pop].shape[0]  ### FIX ###
+                tgid_count = id_mapping[dst_node_pop].shape[0]  ### FIX ###
 
             # after the h5 file is closed, it's indexed if valid, or it's removed if empty
             if edge_count > 0:
@@ -466,7 +473,14 @@ def _write_subcircuit_edges(
                 src_mapping=src_mapping,
                 dst_mapping=dst_mapping,
             )
-            edge_count, sgid_count, tgid_count = _get_node_counts(h5out, dst_edge_pop_name)
+            ### edge_count, sgid_count, tgid_count = _get_node_counts(h5out, dst_edge_pop_name)  ### ERROR ###
+            # Note: _get_node_counts() returns the node counts based on the node indices that are actually present
+            #       in the edge table. However, in case of unconnected nodes this count may be too low, leading
+            #       to a wrong computation of the index vectors in _write_indexes() which should always have the
+            #       same length as the number of nodes, no matter whether or not they are connected!!
+            edge_count, _, _ = _get_node_counts(h5out, dst_edge_pop_name)  ### FIX ###
+            sgid_count = src_mapping.shape[0]  ### FIX ###
+            tgid_count = dst_mapping.shape[0]  ### FIX ###
 
             if edge_count == 0:
                 del h5out[f"/edges/{dst_edge_pop_name}"]

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -284,14 +284,9 @@ def _write_edges(
                     dst_mapping=id_mapping[dst_node_pop],
                     h5_read_chunk_size=h5_read_chunk_size,
                 )
-                ### edge_count, sgid_count, tgid_count = _get_node_counts(h5out, edge_pop_name)  ### ERROR ###
-                # Note: _get_node_counts() returns the node counts based on the node indices that are actually present
-                #       in the edge table. However, in case of unconnected nodes this count may be too low, leading
-                #       to a wrong computation of the index vectors in _write_indexes() which should always have the
-                #       same length as the number of nodes, no matter whether or not they are connected!!
-                edge_count, _, _ = _get_node_counts(h5out, edge_pop_name)  ### FIX ###
-                sgid_count = id_mapping[src_node_pop].shape[0]  ### FIX ###
-                tgid_count = id_mapping[dst_node_pop].shape[0]  ### FIX ###
+                edge_count, _, _ = _get_node_counts(h5out, edge_pop_name)
+                sgid_count = id_mapping[src_node_pop].shape[0]  # Actual node count for writing the indexes, no matter if connected or not
+                tgid_count = id_mapping[dst_node_pop].shape[0]  # Actual node count for writing the indexes, no matter if connected or not
 
             # after the h5 file is closed, it's indexed if valid, or it's removed if empty
             if edge_count > 0:
@@ -473,14 +468,9 @@ def _write_subcircuit_edges(
                 src_mapping=src_mapping,
                 dst_mapping=dst_mapping,
             )
-            ### edge_count, sgid_count, tgid_count = _get_node_counts(h5out, dst_edge_pop_name)  ### ERROR ###
-            # Note: _get_node_counts() returns the node counts based on the node indices that are actually present
-            #       in the edge table. However, in case of unconnected nodes this count may be too low, leading
-            #       to a wrong computation of the index vectors in _write_indexes() which should always have the
-            #       same length as the number of nodes, no matter whether or not they are connected!!
-            edge_count, _, _ = _get_node_counts(h5out, dst_edge_pop_name)  ### FIX ###
-            sgid_count = src_mapping.shape[0]  ### FIX ###
-            tgid_count = dst_mapping.shape[0]  ### FIX ###
+            edge_count, _, _ = _get_node_counts(h5out, dst_edge_pop_name)
+            sgid_count = src_mapping.shape[0]  # Actual node count for writing the indexes, no matter if connected or not
+            tgid_count = dst_mapping.shape[0]  # Actual node count for writing the indexes, no matter if connected or not
 
             if edge_count == 0:
                 del h5out[f"/edges/{dst_edge_pop_name}"]

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -850,13 +850,13 @@ def _write_mapping(output, id_mapping):
     utils.dump_json(output / "id_mapping.json", mapping)
 
 
-def split_subcircuit(output, node_set_name, circuit_config_path, do_virtual, create_external):
+def split_subcircuit(output, node_set_name, circuit, do_virtual, create_external):
     """Split a single subcircuit out of circuit, based on nodeset
 
     Args:
         output(str): path where files will be written
         node_set_name(str): name of nodeset to extract
-        circuit_config_path(str): path to circuit_config sonata file
+        circuit(bluepysnap.Circuit|str): Sonata circuit object or path to circuit_config sonata file
         do_virtual(bool): whether to split out the virtual nodes that target the cells
             contained in the specified nodeset
         create_external(bool): whether to create new virtual populations of all the
@@ -865,7 +865,10 @@ def split_subcircuit(output, node_set_name, circuit_config_path, do_virtual, cre
     # pylint: disable=too-many-locals
     output = Path(output)
 
-    circuit = bluepysnap.Circuit(circuit_config_path)
+    if isinstance(circuit, str):
+        circuit = bluepysnap.Circuit(circuit)
+    else:
+        assert isinstance(circuit, bluepysnap.Circuit), "Path or sonata circuit object required!"
 
     node_pop_to_paths, edge_pop_to_paths = _gather_layout_from_networks(circuit.config["networks"])
 

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -14,6 +14,37 @@ from brainbuilder.utils.sonata import split_population
 DATA_PATH = (Path(__file__).parent / "../data/sonata/split_population/").resolve()
 
 
+def _check_edge_indices(nodes_file, edges_file):
+    def check_index_consistency(node2range, range2edge, ids):
+        for id_ in range(node2range.shape[0]):
+            range_start, range_end = node2range[id_, :]
+            for edge_start, edge_end in range2edge[range_start:range_end, :]:
+                assert all(ids[edge_start:edge_end] == id_)
+
+    with h5py.File(edges_file, "r") as h5edges, h5py.File(nodes_file, "r") as h5nodes:
+        for pop_name in h5edges["edges"]:
+            base_path = "edges/" + pop_name
+
+            src_pop = h5edges[base_path + "/source_node_id"].attrs["node_population"]
+            tgt_pop = h5edges[base_path + "/target_node_id"].attrs["node_population"]
+
+            src_node2range = h5edges[base_path + "/indices/source_to_target/node_id_to_ranges"][:]
+            tgt_node2range = h5edges[base_path + "/indices/target_to_source/node_id_to_ranges"][:]
+
+            # check index length is equal to population size
+            assert src_node2range.shape[0] == h5nodes["nodes"][src_pop]["node_type_id"].shape[0]
+            assert tgt_node2range.shape[0] == h5nodes["nodes"][tgt_pop]["node_type_id"].shape[0]
+
+            src_range2edge = h5edges[base_path + "/indices/source_to_target/range_to_edge_id"][:]
+            tgt_range2edge = h5edges[base_path + "/indices/target_to_source/range_to_edge_id"][:]
+
+            src_ids = h5edges[base_path + "/source_node_id"][:]
+            tgt_ids = h5edges[base_path + "/target_node_id"][:]
+
+            check_index_consistency(src_node2range, src_range2edge, src_ids)
+            check_index_consistency(tgt_node2range, tgt_range2edge, tgt_ids)
+
+
 def test__get_population_name():
     assert "src__dst__chemical" == split_population._get_population_name(src="src", dst="dst")
     assert "src" == split_population._get_population_name(src="src", dst="src")
@@ -186,6 +217,7 @@ def test_split_population(tmp_path):
     utils.assert_json_files_equal(
         tmp_path / "circuit_config.json", expected_dir / "circuit_config.json"
     )
+    _check_edge_indices(nodes_path, edges_path)
 
 
 def test__split_population_by_node_set():
@@ -604,47 +636,6 @@ def test_split_subcircuit_with_virtual(tmp_path):
     assert virtual_pop == {"V2__C": {"type": "chemical"}}
 
 
-def _check_edge_indices(path):
-    nodes_file = path / "nodes" / "nodes.h5"
-    edges_file = path / "edges" / "edges.h5"
-    with h5py.File(edges_file, "r") as h5edges:
-        epops = list(h5edges["edges"].keys())
-        with h5py.File(nodes_file, "r") as h5nodes:
-            for epop in epops:
-                src_npop = h5edges["edges"][epop]["source_node_id"].attrs["node_population"]
-                src_pop_size = len(np.array(h5nodes["nodes"][src_npop]["node_type_id"]))
-
-                tgt_npop = h5edges["edges"][epop]["target_node_id"].attrs["node_population"]
-                tgt_pop_size = len(np.array(h5nodes["nodes"][tgt_npop]["node_type_id"]))
-
-                src_idx_to_rng = np.array(h5edges["edges"][epop]["indices"]["source_to_target"]["node_id_to_ranges"])
-                tgt_idx_to_rng = np.array(h5edges["edges"][epop]["indices"]["target_to_source"]["node_id_to_ranges"])
-
-                src_ind_len = src_idx_to_rng.shape[0]
-                tgt_ind_len = tgt_idx_to_rng.shape[0]
-
-                # Check correct lengths
-                assert src_ind_len == src_pop_size
-                assert tgt_ind_len == tgt_pop_size
-    
-                src_rng_to_eid = np.array(h5edges["edges"][epop]["indices"]["source_to_target"]["range_to_edge_id"])
-                tgt_rng_to_eid = np.array(h5edges["edges"][epop]["indices"]["target_to_source"]["range_to_edge_id"])
-
-                src_nid = np.array(h5edges["edges"][epop]["source_node_id"])
-                tgt_nid = np.array(h5edges["edges"][epop]["target_node_id"])
-
-                # Check actual source/target indexing
-                for _nidx in range(src_ind_len):
-                    _eid_ranges = src_rng_to_eid[range(*src_idx_to_rng[_nidx, :]), :]
-                    for _eid_rng in _eid_ranges:
-                        assert all(src_nid[range(*_eid_rng)] == _nidx)
-
-                for _nidx in range(tgt_ind_len):
-                    _eid_ranges = tgt_rng_to_eid[range(*tgt_idx_to_rng[_nidx, :]), :]
-                    for _eid_rng in _eid_ranges:
-                        assert all(tgt_nid[range(*_eid_rng)] == _nidx)
-
-
 def test_split_subcircuit_edge_indices(tmp_path):
     node_set_name = "mtype_a"
     circuit_config_path = str(DATA_PATH / "split_subcircuit" / "circuit_config.json")
@@ -654,4 +645,7 @@ def test_split_subcircuit_edge_indices(tmp_path):
     )
 
     _check_biophysical_nodes(path=tmp_path, has_virtual=False, has_external=False)
-    _check_edge_indices(path=tmp_path)
+
+    nodes_path = tmp_path / "nodes" / "nodes.h5"
+    edges_path = tmp_path / "edges" / "edges.h5"
+    _check_edge_indices(nodes_path, edges_path)

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -623,7 +623,6 @@ def _check_edge_indices(path):
         epops = list(h5edges["edges"].keys())
         with h5py.File(nodes_file, "r") as h5nodes:
             for epop in epops:
-                print(epop)
                 src_npop = h5edges["edges"][epop]["source_node_id"].attrs["node_population"]
                 src_pop_size = len(np.array(h5nodes["nodes"][src_npop]["node_type_id"]))
 

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -629,10 +629,29 @@ def _check_edge_indices(path):
                 tgt_npop = h5edges["edges"][epop]["target_node_id"].attrs["node_population"]
                 tgt_pop_size = len(np.array(h5nodes["nodes"][tgt_npop]["node_type_id"]))
 
-                src_ind_len = np.array(h5edges["edges"][epop]["indices"]["source_to_target"]["node_id_to_ranges"]).shape[0]
-                tgt_ind_len = np.array(h5edges["edges"][epop]["indices"]["target_to_source"]["node_id_to_ranges"]).shape[0]
+                src_idx_to_rng = np.array(h5edges["edges"][epop]["indices"]["source_to_target"]["node_id_to_ranges"])
+                tgt_idx_to_rng = np.array(h5edges["edges"][epop]["indices"]["target_to_source"]["node_id_to_ranges"])
 
+                src_ind_len = src_idx_to_rng.shape[0]
+                tgt_ind_len = tgt_idx_to_rng.shape[0]
+
+                # Check correct lengths
                 assert src_ind_len == src_pop_size
                 assert tgt_ind_len == tgt_pop_size
     
-    
+                src_rng_to_eid = np.array(h5edges["edges"][epop]["indices"]["source_to_target"]["range_to_edge_id"])
+                tgt_rng_to_eid = np.array(h5edges["edges"][epop]["indices"]["target_to_source"]["range_to_edge_id"])
+
+                src_nid = np.array(h5edges["edges"][epop]["source_node_id"])
+                tgt_nid = np.array(h5edges["edges"][epop]["target_node_id"])
+
+                # Check actual source/target indexing
+                for _nidx in range(src_ind_len):
+                    _eid_ranges = src_rng_to_eid[range(*src_idx_to_rng[_nidx, :]), :]
+                    for _eid_rng in _eid_ranges:
+                        assert all(src_nid[range(*_eid_rng)] == _nidx)
+
+                for _nidx in range(tgt_ind_len):
+                    _eid_ranges = tgt_rng_to_eid[range(*tgt_idx_to_rng[_nidx, :]), :]
+                    for _eid_rng in _eid_ranges:
+                        assert all(tgt_nid[range(*_eid_rng)] == _nidx)

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -604,18 +604,6 @@ def test_split_subcircuit_with_virtual(tmp_path):
     assert virtual_pop == {"V2__C": {"type": "chemical"}}
 
 
-def test_split_subcircuit_edge_indices(tmp_path):
-    node_set_name = "mtype_a"
-    circuit_config_path = str(DATA_PATH / "split_subcircuit" / "circuit_config.json")
-
-    split_population.split_subcircuit(
-        tmp_path, node_set_name, circuit_config_path, do_virtual=False, create_external=False
-    )
-
-    _check_biophysical_nodes(path=tmp_path, has_virtual=False, has_external=False)
-    _check_edge_indices(path=tmp_path)
-
-
 def _check_edge_indices(path):
     nodes_file = path / "nodes" / "nodes.h5"
     edges_file = path / "edges" / "edges.h5"
@@ -655,3 +643,15 @@ def _check_edge_indices(path):
                     _eid_ranges = tgt_rng_to_eid[range(*tgt_idx_to_rng[_nidx, :]), :]
                     for _eid_rng in _eid_ranges:
                         assert all(tgt_nid[range(*_eid_rng)] == _nidx)
+
+
+def test_split_subcircuit_edge_indices(tmp_path):
+    node_set_name = "mtype_a"
+    circuit_config_path = str(DATA_PATH / "split_subcircuit" / "circuit_config.json")
+
+    split_population.split_subcircuit(
+        tmp_path, node_set_name, circuit_config_path, do_virtual=False, create_external=False
+    )
+
+    _check_biophysical_nodes(path=tmp_path, has_virtual=False, has_external=False)
+    _check_edge_indices(path=tmp_path)


### PR DESCRIPTION
`_get_node_counts()` returns the node counts based on the node indices that are actually present in a given edge population. However, in case of unconnected nodes (esp. when extracting very small sub-circuits) this count may be too low, leading to a wrong calculation of the index vectors in `_write_indexes()` which should always have the same lengths as the number of source/target nodes, no matter whether or not they are connected.

To address this, I added a small fix with minimal changes to the existing code, by always using the actual node count for writing the index vectors, no matter if connected or not.

Also, I added a new unit test to explicitly check the result of edge indexing, which would fail without the fix but passes when the fix is applied.