### PR TITLE
Fix for empty virtual source node population

### DIFF
--- a/tests/unit/data/sonata/split_population/split_subcircuit/node_sets.json
+++ b/tests/unit/data/sonata/split_population/split_subcircuit/node_sets.json
@@ -2,5 +2,6 @@
     "mtype_a": {"mtype": "a"},
     "someA": {"population": "A", "node_id": [0, 1, 2] },
     "allB": {"population": "B", "node_id": [0, 1, 2, 3, 4, 5] },
+    "someB": {"population": "B", "node_id": [2, 3, 4] },
     "noC": {"population": "C", "node_id": [] }
 }

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -681,6 +681,24 @@ def test_split_subcircuit_with_virtual(tmp_path, circuit, from_subcircuit):
     assert virtual_pop == {"V2__C": {"type": "chemical"}}
 
 
+@pytest.mark.parametrize(
+    "circuit,from_subcircuit",
+    [
+        (DATA_PATH / "split_subcircuit" / "circuit_config.json", False),
+        (bluepysnap.Circuit(DATA_PATH / "split_subcircuit" / "circuit_config.json"), False),
+        (DATA_PATH / "split_subcircuit" / "circuit_config_subcircuit.json", True),
+        (bluepysnap.Circuit(DATA_PATH / "split_subcircuit" / "circuit_config_subcircuit.json"), True),
+    ],
+)
+def test_split_subcircuit_with_empty_virtual(tmp_path, circuit, from_subcircuit):
+    node_set_name = "someB"
+    split_population.split_subcircuit(
+        tmp_path, node_set_name, circuit, do_virtual=True, create_external=False
+    )
+
+    # TODO: Add additional checks
+
+
 def test_split_subcircuit_edge_indices(tmp_path):
     node_set_name = "mtype_a"
     circuit_config_path = str(DATA_PATH / "split_subcircuit" / "circuit_config.json")


### PR DESCRIPTION
Fix for an error that happens whenever the list of extracted virtual source node IDs is empty, i.e., whenever a virtual population is not innervating any of the extracted neurons.