### PR TITLE
Add `brainbuilder sonata resize-datatypes` command

### DIFF
--- a/brainbuilder/app/sonata.py
+++ b/brainbuilder/app/sonata.py
@@ -413,3 +413,39 @@ def clip_morphologies(output, circuit, population_name):
     from brainbuilder.utils.sonata import clip
 
     clip.morphologies(output, circuit, population_name)
+
+
+@app.command()
+@click.option(
+    "-f",
+    "--file",
+    required=True,
+    type=REQUIRED_PATH,
+    help="`node` or `edges` file, modified in place",
+)
+@click.option("--population-name", required=True, help="Name of population")
+@click.option("--population-type", required=True, help="Type of population (ex: biophysics)")
+@click.option(
+    "-a",
+    "--attributes",
+    multiple=True,
+    required=True,
+    help="Names of the attributes, can be specified multiple times.",
+)
+def resize_datatypes(file, population_name, population_type, attributes):
+    """In place resize attributes to their minimum sizes for SONATA nodes or edges files"""
+    from brainbuilder.utils.sonata import curate
+
+    updates = curate.resize_datatypes(
+        h5_path=file,
+        population_name=population_name,
+        population_type=population_type,
+        attributes=attributes,
+    )
+
+    updates = "\n".join(
+        f"\t{attr} {old_dtype} -> {new_dtype}" for attr, old_dtype, new_dtype in updates
+    )
+
+    click.secho(f"The following updates were performed:\n{updates}")
+    click.secho(f"One should run `h5repack {file} output.h5` to repack the file", fg="green")

--- a/brainbuilder/utils/sonata/curate.py
+++ b/brainbuilder/utils/sonata/curate.py
@@ -386,6 +386,51 @@ def _update_dtype(parent_h5, name, target_dtype):
     return (parent_h5[name].name, target_dtype)
 
 
+def resize_datatypes(h5_path, population_name, population_type, attributes):
+    with h5py.File(h5_path, "r") as h5:
+        if f"nodes/{population_name}" not in h5 and f"edges/{population_name}" not in h5:
+            raise ValueError(f'"{population_name}" dose not exist in `nodes` and `edges`')
+        elif f"nodes/{population_name}" in h5 and f"edges/{population_name}" in h5:
+            raise ValueError(f'"{population_name}" exists in both `nodes` and `edges`')
+        elif f"nodes/{population_name}" in h5:
+            typ_ = "nodes"
+            property_types, dynamics_params = schemas.nodes_schema_types(population_type)
+            overlap = set(property_types).intersection(set(dynamics_params))
+            if overlap := overlap.intersection(attributes):
+                raise RuntimeError(
+                    f"Can't update {overlap} since exist in both property and dynamics"
+                )
+            to_update = {a: property_types[a] for a in attributes if a in property_types}
+            to_update.update(
+                {
+                    f"dynamics_params/{a}": types
+                    for a, types in dynamics_params.items()
+                    if a in attributes
+                }
+            )
+        elif f"edges/{population_name}" in h5:
+            typ_ = "edges"
+            property_types = schemas.edges_schema_types(population_type, virtual=None)
+            to_update = {a: property_types[a] for a in attributes if a in property_types}
+
+    updates = []
+    with h5py.File(h5_path, "r+") as h5:
+        parent_h5 = h5[typ_][population_name]["0"]
+        for attr, dtypes in to_update.items():
+            old_dtype = parent_h5[attr].dtype
+            if isinstance(dtypes, list):
+                max_ = np.max(parent_h5[attr][:])
+                dtype = np.min_scalar_type(max_)
+                if dtype in dtypes and dtype != old_dtype:
+                    _update_dtype(parent_h5, attr, np.dtype(dtype))
+                    updates.append((attr, old_dtype, np.dtype(dtype)))
+            elif old_dtype != dtypes:
+                _update_dtype(parent_h5, attr, np.dtype(dtypes))
+                updates.append((attr, old_dtype, np.dtype(dtypes)))
+
+    return updates
+
+
 def update_node_dtypes(h5_file, population_name, population_type):
     """Update the datatypes of the attributes within a node population to the SONATA spec.
 

--- a/brainbuilder/utils/sonata/curate.py
+++ b/brainbuilder/utils/sonata/curate.py
@@ -372,11 +372,34 @@ def check_morphology_invariants(h5_morph_dir, morph_names):
 
 
 def _update_dtype(parent_h5, name, target_dtype):
-    """Update dtype of the `parent_h5[name]` h5py dataset to `target_dtype`."""
+    """Update dtype of the `parent_h5[name]` h5py dataset to `target_dtype`.
+
+    If a list is passed as `target_dtype`, the tightest fit will be chosen.
+    """
     h5 = parent_h5[name]
     attrs = dict(h5.attrs)
+    old_dtype = h5.dtype
     L.debug("convert_dtype: %s: %s -> %s", h5.name, h5.dtype, target_dtype)
-    new = np.asarray(h5[:], dtype=target_dtype)
+
+    data = h5[:]
+
+    if isinstance(target_dtype, list):
+        dtype = np.min_scalar_type(data.max())
+        if dtype not in target_dtype:
+            msg = (
+                "The minimum dtype is not provided in the list of acceptable dtypes."
+                " No other heuristics are given"
+            )
+            raise RuntimeError(msg)
+        target_dtype = dtype
+    elif np.issubdtype(target_dtype, np.integer):
+        info = np.iinfo(target_dtype)
+        if data.min() < info.min or data.max() > info.max:
+            msg = f"Data in {name} of dtype {old_dtype} does not fit in {target_dtype}"
+            raise RuntimeError(msg)
+
+    new = np.asarray(data, dtype=target_dtype)
+
     del parent_h5[name]
     parent_h5[name] = new
 
@@ -398,14 +421,14 @@ def resize_datatypes(h5_path, population_name, population_type, attributes):
             overlap = set(property_types).intersection(set(dynamics_params))
             if overlap := overlap.intersection(attributes):
                 raise RuntimeError(
-                    f"Can't update {overlap} since exist in both property and dynamics"
+                    f"Can't update {overlap} since it exists in both property and dynamics"
                 )
             to_update = {a: property_types[a] for a in attributes if a in property_types}
             to_update.update(
                 {
-                    f"dynamics_params/{a}": types
-                    for a, types in dynamics_params.items()
-                    if a in attributes
+                    f"dynamics_params/{a}": dynamics_params[a]
+                    for a in attributes
+                    if a in dynamics_params
                 }
             )
         elif f"edges/{population_name}" in h5:
@@ -466,7 +489,7 @@ def update_node_dtypes(h5_file, population_name, population_type):
             else:
                 parent = group
 
-            if target_dtype != parent[attribute_name].dtype:
+            if target_dtype != parent[attribute_name].dtype or isinstance(target_dtype, list):
                 converted.append(_update_dtype(parent, attribute_name, target_dtype))
 
         if "dynamics_params" in group:
@@ -476,7 +499,7 @@ def update_node_dtypes(h5_file, population_name, population_type):
                     continue
 
                 target_dtype = dynamics_params[param]
-                if target_dtype != parent[param].dtype:
+                if target_dtype != parent[param].dtype or isinstance(target_dtype, list):
                     converted.append(_update_dtype(parent, param, target_dtype))
 
     return dict(converted)
@@ -518,7 +541,7 @@ def update_edge_dtypes(h5_file, population_name, population_type, virtual):
             if target_dtype is str:
                 continue
 
-            if target_dtype != group[attribute_name].dtype:
+            if target_dtype != group[attribute_name].dtype or isinstance(target_dtype, list):
                 converted.append(_update_dtype(group, attribute_name, target_dtype))
 
     return dict(converted)

--- a/doc/source/cli.rst
+++ b/doc/source/cli.rst
@@ -57,6 +57,7 @@ The following subcommands can be used with: ``brainbuilder sonata``
 * ``clip-morphologies``                    Copy morphologies referenced by a population to a separate output directory
 * ``update-edge-section-types``            Update edge afferent/efferent section types using section_id
 * ``update-projection-efferent-edge-type`` Write projections' efferent section types as axons
+* ``resize-datatypes``                     Update attributes to fit in the smallest acceptable datatype
 
 For the commands starting with _update-_, read more in :ref:`SONATA: Single Child Reindex`
 

--- a/tests/unit/test_sonata/test_curate.py
+++ b/tests/unit/test_sonata/test_curate.py
@@ -225,3 +225,29 @@ def test_update_edge_dtypes(tmp_path):
     converted = curate.update_edge_dtypes(edges_copy_file, "not-default", "chemical", virtual=False)
     assert converted["/edges/not-default/0/efferent_surface_z"] == np.float32
     assert converted["/edges/not-default/edge_type_id"] == np.int64
+
+
+def test_resize_datatypes(tmp_path):
+    nodes_copy_file = shutil.copy2(NODES_FILE, tmp_path)
+    updates = curate.resize_datatypes(
+        nodes_copy_file,
+        population_name="not-default",
+        population_type="biophysical",
+        attributes=["holding_current", "x"],
+    )
+    assert updates == [
+        ("x", np.dtype("<f8"), np.dtype("float32")),
+        ("dynamics_params/holding_current", np.dtype("<f8"), np.dtype("float32")),
+    ]
+
+    edges_copy_file = shutil.copy2(EDGES_FILE, tmp_path)
+    updates = curate.resize_datatypes(
+        edges_copy_file,
+        population_name="not-default",
+        population_type="chemical",
+        attributes=["efferent_surface_y", "afferent_section_id"],
+    )
+    assert updates == [
+        ("efferent_surface_y", np.dtype("<f8"), np.dtype("float32")),
+        ("afferent_section_id", np.dtype("int64"), np.dtype("uint8")),
+    ]

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ ignore_basepython_conflict = true
 [testenv]
 extras = all
 deps = {[base]testdeps}
-commands = pytest {[base]pytest_options} tests/unit {posargs}
+commands = pytest {[base]pytest_options} {posargs:tests/unit }
 
 [testenv:check-packaging]
 skip_install = true


### PR DESCRIPTION
Allows giving an node/edge file and a population, along with which attributes should be rewritten to occupy less space.

ex:
    brainbuilder sonata resize-datatypes \
    --file edges.h5 \
    --population-type chemical \
    --population-name not-default \
    --attributes efferent_section_id \
    --attributes afferent_section_id