### PR TITLE
split a sub sub circuit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build
 .tox
 .idea
 .vscode
+.kiro
 venv
 dist
 brainbuilder/version.py

--- a/brainbuilder/app/sonata.py
+++ b/brainbuilder/app/sonata.py
@@ -449,3 +449,22 @@ def resize_datatypes(file, population_name, population_type, attributes):
 
     click.secho(f"The following updates were performed:\n{updates}")
     click.secho(f"One should run `h5repack {file} output.h5` to repack the file", fg="green")
+
+
+@app.command()
+@click.argument("circuit-config", type=REQUIRED_PATH)
+@click.option("-o", "--output", help="Save to file (e.g., circuit.png). Otherwise opens viewer.")
+@click.option("-t", "--title", help="Title for the graph (default: parent directory name)")
+def visualize(circuit_config, output, title):
+    """Display a graph of circuit connectivity grouped by population.
+
+    Requires: pip install brainbuilder[viz] and system graphviz.
+    """
+    from brainbuilder.utils.sonata.visualize import draw_circuit
+
+    if not title:
+        title = Path(circuit_config).parent.name
+
+    draw_circuit(circuit_config, output_path=output, title=title)
+    if output:
+        click.echo(f"Saved to {output}")

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -830,7 +830,7 @@ def _gather_new_external_subcircuits(
     Returns:
         (write_edge_configs, nodes_to_write):
             write_edge_configs: list of WriteEdgeConfig
-            nodes_to_write: dict of output_pop_name -> (source_pop_name, node_ids)
+            nodes_to_write: dict of output_pop_name -> list of (source_pop_name, node_ids)
     """
 
     assert all(edge.type != "neuroglial" for edge in circuit.edges.values()), (
@@ -842,12 +842,15 @@ def _gather_new_external_subcircuits(
     )
 
     nodes_to_write = {}
-    id_mapping_secondary = {}
 
     write_edge_configs = []
     for name, edge in circuit.edges.items():
+        L.debug("GATHER-ALL: edge=%s, src_type=%s, target=%s, target_in_mapping=%s",
+                name, edge.source.type, edge.target.name, edge.target.name in id_mapping)
         if edge.source.type != "virtual" and edge.target.name in id_mapping:
             wanted_src_ids = circuit.nodes[edge.source.name].ids()
+            L.debug("GATHER: edge=%s, source=%s, target=%s, all_src_ids=%s",
+                    name, edge.source.name, edge.target.name, wanted_src_ids.tolist())
 
             if edge.source.name in id_mapping:
                 wanted_src_ids = wanted_src_ids[
@@ -856,14 +859,10 @@ def _gather_new_external_subcircuits(
                     )
                 ]
 
-            # only keep ids that are used; this is duplicating work in _copy_edge_attributes
-            # but the alternative is that it keeps track of the new id_mapping; which
-            # seemed less ideal
             with h5py.File(_get_storage_path(edge)) as h5:
                 all_sgids = h5[f"edges/{name}/source_node_id"]
                 all_tgids = h5[f"edges/{name}/target_node_id"]
 
-                # overwrite wanted_src_ids with a DataFrame; the numpy array is not needed
                 wanted_src_ids = _get_subcircuit_external_ids(
                     all_sgids,
                     all_tgids,
@@ -896,60 +895,22 @@ def _gather_new_external_subcircuits(
             )
 
             if new_source_pop_name in id_mapping:
-                # If mapping already exists, only add new IDs w/o changing existing!
-                # (May happen if different target populations have same external source population)
+                # Same source, multiple target populations — deduplicate and extend
                 existing_mapping = id_mapping[new_source_pop_name]
-
-                # Check if existing mapping came from a different source population
-                # Compare against the first (primary) parent only
-                existing_parents = node_pop_name_mapping.get(new_source_pop_name, [])
-                different_source = existing_parents and existing_parents[0] != edge.source.name
-
-                if different_source:
-                    # Nodes from a different parent population — store separately
-                    # to avoid index collisions. Will be merged at write time.
-                    # Deduplicate against already-added secondary nodes
-                    if new_source_pop_name in id_mapping_secondary:
-                        already_added = id_mapping_secondary[new_source_pop_name]
-                        is_existing = _isin(wanted_src_ids.index, already_added.index)
-                        wanted_src_ids.loc[is_existing] = already_added.loc[
-                            wanted_src_ids.loc[is_existing].index
-                        ]
-                        if is_existing.any():
-                            max_existing_id = already_added[NEW_IDS].max()
-                        else:
-                            max_existing_id = existing_mapping[NEW_IDS].max()
-                        n_new = int(np.sum(~is_existing))
-                        if n_new > 0:
-                            new_ids = np.arange(n_new) + int(max_existing_id) + 1
-                            wanted_src_ids.loc[~is_existing, NEW_IDS] = new_ids
-                            id_mapping_secondary[new_source_pop_name] = pd.concat(
-                                [already_added, wanted_src_ids.loc[~is_existing]], axis=0
-                            )
-                    else:
-                        max_existing_id = existing_mapping[NEW_IDS].max()
-                        new_ids = np.arange(len(wanted_src_ids)) + int(max_existing_id) + 1
-                        wanted_src_ids[NEW_IDS] = new_ids
-                        id_mapping_secondary[new_source_pop_name] = wanted_src_ids
-                    if edge.source.name not in node_pop_name_mapping[new_source_pop_name]:
-                        node_pop_name_mapping[new_source_pop_name].append(edge.source.name)
+                is_existing = _isin(wanted_src_ids.index, existing_mapping.index)
+                wanted_src_ids.loc[is_existing] = existing_mapping.loc[
+                    wanted_src_ids.loc[is_existing].index
+                ]
+                if is_existing.any():
+                    max_existing_id = wanted_src_ids[NEW_IDS].loc[is_existing].max()
                 else:
-                    is_existing = _isin(wanted_src_ids.index, existing_mapping.index)
-                    wanted_src_ids.loc[is_existing] = existing_mapping.loc[
-                        wanted_src_ids.loc[is_existing].index
-                    ]
-                    # New node IDs begin at the lowest unused value (max + 1).
-                    if is_existing.any():
-                        max_existing_id = wanted_src_ids[NEW_IDS].loc[is_existing].max()
-                    else:
-                        max_existing_id = existing_mapping[NEW_IDS].max()
-                    new_ids = np.arange(np.sum(~is_existing)) + int(max_existing_id) + 1
-                    wanted_src_ids.loc[~is_existing, NEW_IDS] = new_ids
+                    max_existing_id = existing_mapping[NEW_IDS].max()
+                new_ids = np.arange(np.sum(~is_existing)) + int(max_existing_id) + 1
+                wanted_src_ids.loc[~is_existing, NEW_IDS] = new_ids
 
-                    # And merge new into existing
-                    id_mapping[new_source_pop_name] = pd.concat(
-                        [existing_mapping, wanted_src_ids.loc[~is_existing]], axis=0
-                    )
+                id_mapping[new_source_pop_name] = pd.concat(
+                    [existing_mapping, wanted_src_ids.loc[~is_existing]], axis=0
+                )
             else:
                 id_mapping[new_source_pop_name] = wanted_src_ids
 
@@ -966,27 +927,14 @@ def _gather_new_external_subcircuits(
             )
             write_edge_configs.append(write_edge_config)
 
-            # Build nodes_to_write for this population.
-            # Only include nodes that _gather is responsible for (not filter's).
-            if new_source_pop_name in id_mapping_secondary:
-                # Mixed source: only write the secondary (new biophysical) nodes.
-                # The primary (carried-over external) nodes are handled by _filter.
-                nodes_to_write[new_source_pop_name] = [
-                    (
-                        edge.source.name,
-                        id_mapping_secondary[new_source_pop_name].index.to_numpy(),
-                    )
-                ]
-            else:
-                # Single source: all nodes come from _gather
-                nodes_to_write[new_source_pop_name] = [
-                    (
-                        edge.source.name,
-                        id_mapping[new_source_pop_name].index.to_numpy(),
-                    )
-                ]
+            nodes_to_write[new_source_pop_name] = [
+                (
+                    edge.source.name,
+                    id_mapping[new_source_pop_name].index.to_numpy(),
+                )
+            ]
 
-    return write_edge_configs, nodes_to_write, id_mapping_secondary
+    return write_edge_configs, nodes_to_write
 
 
 def _filter_virtual_typed_subcircuit(
@@ -1436,7 +1384,6 @@ def split_subcircuit(
 
     existing_node_pop_names = list(new_node_files.keys())
     existing_edge_pop_names = list(new_edge_files.keys())
-    id_mapping_secondary = {}
     if create_external:
         # Phase A: carry over existing external_ populations from parent circuit
         write_edge_configs_a, nodes_to_write_a = _filter_virtual_typed_subcircuit(
@@ -1450,18 +1397,53 @@ def split_subcircuit(
         )
 
         # Phase B: create new externals from biophysical populations now outside subcircuit
-        (
-            write_edge_configs_b,
-            nodes_to_write_b,
-            id_mapping_secondary,
-        ) = _gather_new_external_subcircuits(
+        # Give _gather a clean id_mapping without filter's external entries
+        gather_id_mapping = {k: v for k, v in id_mapping.items() if not k.startswith("external_")}
+        gather_node_pop_name_mapping = {
+            k: v for k, v in node_pop_name_mapping.items() if not k.startswith("external_")
+        }
+        write_edge_configs_b, nodes_to_write_b = _gather_new_external_subcircuits(
             output,
             circuit,
-            id_mapping,
-            node_pop_name_mapping,
+            gather_id_mapping,
+            gather_node_pop_name_mapping,
             existing_node_pop_names,
             existing_edge_pop_names,
         )
+
+        # Merge: for overlapping populations, renumber gather's new_ids and combine
+        id_mapping_secondary = {}
+        for pop_name in list(gather_id_mapping.keys()):
+            if not pop_name.startswith("external_"):
+                continue
+            gather_df = gather_id_mapping[pop_name]
+            L.debug("MERGE: pop=%s, in id_mapping=%s, gather new_ids=%s",
+                    pop_name, pop_name in id_mapping, gather_df[NEW_IDS].tolist())
+            if pop_name in id_mapping:
+                # Overlapping: renumber gather's IDs after filter's max
+                offset = int(id_mapping[pop_name][NEW_IDS].max()) + 1
+                gather_df[NEW_IDS] = gather_df[NEW_IDS] + offset
+                id_mapping_secondary[pop_name] = gather_df
+                # Update src_mapping in gather's WriteEdgeConfigs
+                for cfg in write_edge_configs_b:
+                    if cfg.src_node_name == pop_name:
+                        new_mappings = []
+                        for m in cfg.src_mapping:
+                            m_copy = m.copy()
+                            m_copy[NEW_IDS] = m_copy[NEW_IDS] + offset
+                            new_mappings.append(m_copy)
+                        cfg.src_mapping = new_mappings
+                # Append parent name
+                if pop_name in gather_node_pop_name_mapping:
+                    for parent in gather_node_pop_name_mapping[pop_name]:
+                        if parent not in node_pop_name_mapping.get(pop_name, []):
+                            node_pop_name_mapping[pop_name].append(parent)
+            else:
+                # Non-overlapping: just move to main id_mapping
+                id_mapping[pop_name] = gather_df
+                node_pop_name_mapping[pop_name] = gather_node_pop_name_mapping.get(
+                    pop_name, [pop_name]
+                )
 
         # Merge edge configs: combine configs with same dst_edge_name into
         # a single multi-input config; leave others as-is.
@@ -1469,7 +1451,6 @@ def split_subcircuit(
         merged_edge_configs = list(write_edge_configs_a)
         for cfg_b in write_edge_configs_b:
             if cfg_b.dst_edge_name in filter_configs_by_name:
-                # Merge into existing config (append inputs)
                 cfg_a = filter_configs_by_name[cfg_b.dst_edge_name]
                 cfg_a.input_path = cfg_a.input_path + cfg_b.input_path
                 cfg_a.src_edge_name = cfg_a.src_edge_name + cfg_b.src_edge_name
@@ -1499,8 +1480,16 @@ def split_subcircuit(
         circuit,
         id_mapping,
         node_pop_name_mapping,
-        id_mapping_secondary,
+        id_mapping_secondary if create_external else None,
     )
+    # Temporary debug assert
+    if create_external and "external_A" in id_mapping_secondary:
+        _sec = id_mapping_secondary["external_A"]
+        _pri = id_mapping["external_A"]
+        assert int(_sec[NEW_IDS].max()) == int(_pri[NEW_IDS].max()) + len(_sec), (
+            f"Secondary new_id mismatch: sec_max={int(_sec[NEW_IDS].max())}, "
+            f"pri_max={int(_pri[NEW_IDS].max())}, sec_len={len(_sec)}"
+        )
 
     config = copy.deepcopy(circuit.config)
 

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -916,11 +916,14 @@ def _write_subcircuit_external(
                 wanted_src_ids.loc[is_existing] = existing_mapping.loc[
                     wanted_src_ids.loc[is_existing].index
                 ]
-                new_ids = (
-                    np.arange(np.sum(~is_existing))
-                    + wanted_src_ids[NEW_IDS].loc[is_existing].max()
-                    + 1
-                )  # New node IDs begin at the lowest unused value (max + 1)
+                # New node IDs begin at the lowest unused value (max + 1).
+                # Use existing_mapping max when no overlap exists (is_existing all False),
+                # otherwise use the max from the overlapping entries in wanted_src_ids.
+                if is_existing.any():
+                    max_existing_id = wanted_src_ids[NEW_IDS].loc[is_existing].max()
+                else:
+                    max_existing_id = existing_mapping[NEW_IDS].max()
+                new_ids = np.arange(np.sum(~is_existing)) + int(max_existing_id) + 1
                 wanted_src_ids.loc[~is_existing, NEW_IDS] = new_ids
 
                 # And merge new into existing

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -963,21 +963,28 @@ def _write_subcircuit_external(
     return new_node_files, new_edges_files
 
 
-def _write_subcircuit_virtual(
-    output,
+def _filter_virtual_typed_subcircuit(
     circuit,
-    edge_populations_to_paths,
     id_mapping,
     node_pop_name_mapping,
+    do_externals,
     list_of_sources_to_ignore=(),
 ):
-    """write all node/edge populations that have virtual nodes as source
+    """Filter and gather virtual-typed source populations for subcircuit extraction.
 
-    Note: the id_mapping dictionary is updated with the used virtual nodes
+    Selects edge populations whose source is typed as virtual and whose target
+    is in `id_mapping`. The `do_externals` flag controls which flavor:
+      - False: only genuine virtuals (excluding external_* populations)
+      - True: only external_* populations
+
+    Updates `id_mapping` and `node_pop_name_mapping` in place with the selected
+    source populations.
+
+    Returns:
+        (virtual_populations, pop_used_source_node_ids):
+            virtual_populations: dict of edge_name -> edge object
+            pop_used_source_node_ids: dict of source_pop_name -> array of used node IDs
     """
-    # pylint: disable=too-many-locals
-    new_node_files = {}
-
     virtual_populations = {
         name: edge
         for name, edge in circuit.edges.items()
@@ -985,7 +992,7 @@ def _write_subcircuit_virtual(
             edge.source.type == "virtual"
             and edge.target.name in id_mapping
             and edge.source.name not in list_of_sources_to_ignore
-            and not edge.source.name.startswith("external_")
+            and (edge.source.name.startswith("external_") == do_externals)
         )
     }
 
@@ -1015,14 +1022,37 @@ def _write_subcircuit_virtual(
         if edge.source.name in pop_used_source_node_ids
     }
 
-    # update the mappings with the virtual nodes
+    # update the mappings with the selected source nodes
     for name, ids in pop_used_source_node_ids.items():
         id_mapping[name] = pd.DataFrame({NEW_IDS: range(len(ids))}, index=ids)
-        # Virtual input sources retain their name unchanged
         node_pop_name_mapping[name] = name
 
-    # write the edges that have the virtual populations as source
+    return virtual_populations, pop_used_source_node_ids
 
+
+def _write_subcircuit(
+    output,
+    circuit,
+    edge_populations_to_paths,
+    id_mapping,
+    virtual_populations,
+    pop_used_source_node_ids,
+):
+    """Write edges and nodes for previously filtered virtual-typed source populations.
+
+    Args:
+        output: Path where files will be written.
+        circuit: bluepysnap Circuit object.
+        edge_populations_to_paths: dict of edge_pop_name -> relative path.
+        id_mapping: dict of pop_name -> DataFrame with new_id column.
+        virtual_populations: dict of edge_name -> edge object (from _filter_virtual_typed_subcircuit).
+        pop_used_source_node_ids: dict of source_pop_name -> array of node IDs
+            (from _filter_virtual_typed_subcircuit).
+
+    Returns:
+        (new_node_files, new_edges_files): dicts of population_name -> path.
+    """
+    # write the edges
     write_edge_configs = []
     for edge_pop_name, edge in virtual_populations.items():
         write_edge_config = WriteEdgeConfig(
@@ -1040,9 +1070,9 @@ def _write_subcircuit_virtual(
 
     new_edges_files = _orchestrate_write_subcircuit_edges(write_edge_configs=write_edge_configs)
 
-    # write virtual nodes based on virtual populations
+    # write nodes
+    new_node_files = {}
     for population_name, ids in pop_used_source_node_ids.items():
-        # Get all properties of the subset of the node population that is relevant
         df = circuit.nodes[population_name].get(ids).reset_index(drop=True)
         nodes_path = Path(output) / population_name / "nodes.h5"
         nodes_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1274,7 +1304,7 @@ def split_subcircuit(
     node_pop_name_mapping = {pop_name: pop_name for pop_name in split_populations.keys()}
 
     # TODO: should function `_write_subcircuit_biological`,
-    # `_write_subcircuit_external`, `_write_subcircuit_virtual`
+    # `_write_subcircuit_external`, `_filter_virtual_typed_subcircuit`/`_write_subcircuit`
     # handle node updates and config updates?
 
     new_node_files, new_edge_files = _write_subcircuit_biological(
@@ -1282,13 +1312,20 @@ def split_subcircuit(
     )
 
     if do_virtual:
-        new_virtual_node_files, new_virtual_edge_files = _write_subcircuit_virtual(
+        virtual_populations, pop_used_source_node_ids = _filter_virtual_typed_subcircuit(
+            circuit,
+            id_mapping,
+            node_pop_name_mapping,
+            False,
+            list_of_virtual_sources_to_ignore,
+        )
+        new_virtual_node_files, new_virtual_edge_files = _write_subcircuit(
             output,
             circuit,
             edge_pop_to_paths,
             id_mapping,
-            node_pop_name_mapping,
-            list_of_virtual_sources_to_ignore,
+            virtual_populations,
+            pop_used_source_node_ids,
         )
 
         new_node_files.update(new_virtual_node_files)
@@ -1297,6 +1334,22 @@ def split_subcircuit(
     existing_node_pop_names = list(new_node_files.keys())
     existing_edge_pop_names = list(new_edge_files.keys())
     if create_external:
+        virtual_populations, pop_used_source_node_ids = _filter_virtual_typed_subcircuit(
+            circuit,
+            id_mapping,
+            node_pop_name_mapping,
+            True,
+            list_of_virtual_sources_to_ignore,
+        )
+        new_virtual_node_files, new_virtual_edge_files = _write_subcircuit(
+            output,
+            circuit,
+            edge_pop_to_paths,
+            id_mapping,
+            virtual_populations,
+            pop_used_source_node_ids,
+        )
+
         new_virtual_node_files, new_virtual_edge_files = _write_subcircuit_external(
             output,
             circuit,

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -832,7 +832,7 @@ def _get_subcircuit_external_ids(all_sgids, all_tgids, wanted_src_ids, wanted_ds
     return ret.sort_index()
 
 
-def _write_subcircuit_external(
+def _gather_new_external_subcircuit(
     output,
     circuit,
     id_mapping,
@@ -840,12 +840,18 @@ def _write_subcircuit_external(
     existing_node_pop_names,
     existing_edge_pop_names,
 ):
-    """Write external connectivity.
+    """Gather external connectivity: non-virtual sources projecting into the subcircuit.
 
-    returns: (new_node_files, new_edges_files); with, respectively,
-    dictionaries with node and edge population_name -> path
+    Identifies source nodes that are NOT in the subcircuit but have edges targeting
+    nodes that ARE in the subcircuit. Builds WriteEdgeConfigs and a nodes_to_write
+    dict suitable for _write_subcircuit.
 
-    Warning: this writes `id_mapping` in place
+    Updates `id_mapping` and `node_pop_name_mapping` in place.
+
+    Returns:
+        (write_edge_configs, nodes_to_write):
+            write_edge_configs: list of WriteEdgeConfig
+            nodes_to_write: dict of output_pop_name -> (source_pop_name, node_ids)
     """
 
     assert all(edge.type != "neuroglial" for edge in circuit.edges.values()), (
@@ -856,7 +862,7 @@ def _write_subcircuit_external(
         "that multiplies the amount of additional files required."
     )
 
-    new_nodes = {}
+    nodes_to_write = {}
 
     write_edge_configs = []
     for name, edge in circuit.edges.items():
@@ -946,25 +952,19 @@ def _write_subcircuit_external(
             )
             write_edge_configs.append(write_edge_config)
 
-            new_nodes[new_source_pop_name] = edge.source.name
+            # Use accumulated id_mapping index for node IDs (merges across all edges)
+            nodes_to_write[new_source_pop_name] = (
+                edge.source.name,
+                id_mapping[new_source_pop_name].index.to_numpy(),
+            )
 
-    new_edges_files = _orchestrate_write_subcircuit_edges(write_edge_configs=write_edge_configs)
-
-    new_node_files = {}
-    # write new virtual nodes from originally non-virtual populations
-    for population_name, orig_population_name in new_nodes.items():
-        # Use the accumulated id_mapping (which merges IDs across all edges)
-        ids = id_mapping[population_name].index.to_numpy()
-        df = circuit.nodes[orig_population_name].get(ids).reset_index(drop=True)
-        nodes_path = Path(output) / population_name / "nodes.h5"
-        nodes_path.parent.mkdir(parents=True, exist_ok=True)
-        new_node_files[population_name] = _save_sonata_nodes(nodes_path, df, population_name)
-
-    return new_node_files, new_edges_files
+    return write_edge_configs, nodes_to_write
 
 
 def _filter_virtual_typed_subcircuit(
+    output,
     circuit,
+    edge_populations_to_paths,
     id_mapping,
     node_pop_name_mapping,
     do_externals,
@@ -981,9 +981,9 @@ def _filter_virtual_typed_subcircuit(
     source populations.
 
     Returns:
-        (virtual_populations, pop_used_source_node_ids):
-            virtual_populations: dict of edge_name -> edge object
-            pop_used_source_node_ids: dict of source_pop_name -> array of used node IDs
+        (write_edge_configs, nodes_to_write):
+            write_edge_configs: list of WriteEdgeConfig
+            nodes_to_write: dict of output_pop_name -> (source_pop_name, node_ids)
     """
     virtual_populations = {
         name: edge
@@ -1027,37 +1027,10 @@ def _filter_virtual_typed_subcircuit(
         id_mapping[name] = pd.DataFrame({NEW_IDS: range(len(ids))}, index=ids)
         node_pop_name_mapping[name] = name
 
-    return virtual_populations, pop_used_source_node_ids
-
-
-def _write_subcircuit(
-    output,
-    circuit,
-    edge_populations_to_paths,
-    id_mapping,
-    virtual_populations,
-    pop_used_source_node_ids,
-):
-    """Write edges and nodes for previously filtered virtual-typed source populations.
-
-    Args:
-        output: Path where files will be written.
-        circuit: bluepysnap Circuit object.
-        edge_populations_to_paths: dict of edge_pop_name -> relative path.
-        id_mapping: dict of pop_name -> DataFrame with new_id column.
-        virtual_populations: dict of edge_name -> edge object (from _filter_virtual_typed_subcircuit).
-        pop_used_source_node_ids: dict of source_pop_name -> array of node IDs
-            (from _filter_virtual_typed_subcircuit).
-
-    Returns:
-        (new_node_files, new_edges_files): dicts of population_name -> path.
-    """
-    # write the edges
-    write_edge_configs = []
-    for edge_pop_name, edge in virtual_populations.items():
-        write_edge_config = WriteEdgeConfig(
+    write_edge_configs = [
+        WriteEdgeConfig(
             output_path=Path(output) / edge_populations_to_paths[edge_pop_name],
-            input_path=_get_storage_path(edge),  # Where to read from
+            input_path=_get_storage_path(edge),
             src_node_name=edge.source.name,
             dst_node_name=edge.target.name,
             src_edge_name=edge_pop_name,
@@ -1066,14 +1039,37 @@ def _write_subcircuit(
             dst_mapping=id_mapping[edge.target.name],
             edge_type=edge.type,
         )
-        write_edge_configs.append(write_edge_config)
+        for edge_pop_name, edge in virtual_populations.items()
+    ]
+    nodes_to_write = {name: (name, ids) for name, ids in pop_used_source_node_ids.items()}
 
+    return write_edge_configs, nodes_to_write
+
+
+def _write_subcircuit(
+    output,
+    circuit,
+    write_edge_configs,
+    nodes_to_write,
+):
+    """Write edges and nodes for a subcircuit extraction step.
+
+    Args:
+        output: Path where files will be written.
+        circuit: bluepysnap Circuit object.
+        write_edge_configs: list of WriteEdgeConfig (fully constructed).
+        nodes_to_write: dict of output_pop_name -> (source_pop_name, node_ids).
+            source_pop_name is the population to read from in the circuit,
+            node_ids are the IDs to extract from that population.
+
+    Returns:
+        (new_node_files, new_edges_files): dicts of population_name -> path.
+    """
     new_edges_files = _orchestrate_write_subcircuit_edges(write_edge_configs=write_edge_configs)
 
-    # write nodes
     new_node_files = {}
-    for population_name, ids in pop_used_source_node_ids.items():
-        df = circuit.nodes[population_name].get(ids).reset_index(drop=True)
+    for population_name, (source_pop_name, ids) in nodes_to_write.items():
+        df = circuit.nodes[source_pop_name].get(ids).reset_index(drop=True)
         nodes_path = Path(output) / population_name / "nodes.h5"
         nodes_path.parent.mkdir(parents=True, exist_ok=True)
         new_node_files[population_name] = _save_sonata_nodes(nodes_path, df, population_name)
@@ -1305,7 +1301,7 @@ def split_subcircuit(
     node_pop_name_mapping = {pop_name: pop_name for pop_name in split_populations.keys()}
 
     # TODO: should function `_write_subcircuit_biological`,
-    # `_write_subcircuit_external`, `_filter_virtual_typed_subcircuit`/`_write_subcircuit`
+    # `_gather_new_external_subcircuit`, `_filter_virtual_typed_subcircuit`/`_write_subcircuit`
     # handle node updates and config updates?
 
     new_node_files, new_edge_files = _write_subcircuit_biological(
@@ -1313,8 +1309,10 @@ def split_subcircuit(
     )
 
     if do_virtual:
-        virtual_populations, pop_used_source_node_ids = _filter_virtual_typed_subcircuit(
+        write_edge_configs, nodes_to_write = _filter_virtual_typed_subcircuit(
+            output,
             circuit,
+            edge_pop_to_paths,
             id_mapping,
             node_pop_name_mapping,
             False,
@@ -1323,10 +1321,8 @@ def split_subcircuit(
         new_virtual_node_files, new_virtual_edge_files = _write_subcircuit(
             output,
             circuit,
-            edge_pop_to_paths,
-            id_mapping,
-            virtual_populations,
-            pop_used_source_node_ids,
+            write_edge_configs,
+            nodes_to_write,
         )
 
         new_node_files.update(new_virtual_node_files)
@@ -1335,8 +1331,10 @@ def split_subcircuit(
     existing_node_pop_names = list(new_node_files.keys())
     existing_edge_pop_names = list(new_edge_files.keys())
     if create_external:
-        virtual_populations, pop_used_source_node_ids = _filter_virtual_typed_subcircuit(
+        write_edge_configs, nodes_to_write = _filter_virtual_typed_subcircuit(
+            output,
             circuit,
+            edge_pop_to_paths,
             id_mapping,
             node_pop_name_mapping,
             True,
@@ -1345,19 +1343,23 @@ def split_subcircuit(
         new_virtual_node_files, new_virtual_edge_files = _write_subcircuit(
             output,
             circuit,
-            edge_pop_to_paths,
-            id_mapping,
-            virtual_populations,
-            pop_used_source_node_ids,
+            write_edge_configs,
+            nodes_to_write,
         )
 
-        new_virtual_node_files, new_virtual_edge_files = _write_subcircuit_external(
+        write_edge_configs, nodes_to_write = _gather_new_external_subcircuit(
             output,
             circuit,
             id_mapping,
             node_pop_name_mapping,
             existing_node_pop_names,
             existing_edge_pop_names,
+        )
+        new_virtual_node_files, new_virtual_edge_files = _write_subcircuit(
+            output,
+            circuit,
+            write_edge_configs,
+            nodes_to_write,
         )
 
         new_node_files.update(new_virtual_node_files)

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -887,9 +887,8 @@ def _gather_new_external_subcircuits(
                 node_pop_name_mapping[new_source_pop_name] = [edge.source.name]
 
             output_path = output / (new_name + ".h5")
-            output_path.parent.mkdir(parents=True, exist_ok=True)
             L.debug(
-                "Writing edges %s for %s -> %s [%s]",
+                "Gathering external edges %s for %s -> %s [%s]",
                 name,
                 edge.source.name,
                 edge.target.name,
@@ -1410,9 +1409,7 @@ def split_subcircuit(
         }
         # Compute per-population offset: new_ids continue after filter's max
         external_offsets = {
-            k: int(v[NEW_IDS].max()) + 1
-            for k, v in id_mapping.items()
-            if k.startswith("external_")
+            k: int(v[NEW_IDS].max()) + 1 for k, v in id_mapping.items() if k.startswith("external_")
         }
         write_edge_configs_b, nodes_to_write_b = _gather_new_external_subcircuits(
             output,

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -914,8 +914,7 @@ def _gather_new_external_subcircuits(
                 )
             else:
                 pop_offset = (external_id_offset or {}).get(new_source_pop_name, 0)
-                if pop_offset:
-                    wanted_src_ids[NEW_IDS] = wanted_src_ids[NEW_IDS] + pop_offset
+                wanted_src_ids[NEW_IDS] = wanted_src_ids[NEW_IDS] + pop_offset
                 id_mapping[new_source_pop_name] = wanted_src_ids
 
             write_edge_config = WriteEdgeConfig(

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -818,6 +818,7 @@ def _gather_new_external_subcircuits(
     node_pop_name_mapping,
     existing_node_pop_names,
     existing_edge_pop_names,
+    external_id_offset=None,
 ):
     """Gather external connectivity: non-virtual sources projecting into the subcircuit.
 
@@ -826,6 +827,11 @@ def _gather_new_external_subcircuits(
     dict suitable for _write_subcircuit.
 
     Updates `id_mapping` and `node_pop_name_mapping` in place.
+
+    Args:
+        external_id_offset: Dict of population_name -> starting new_id offset.
+            Used when merging with pre-existing externals from a parent circuit.
+            If None or population not in dict, offset is 0.
 
     Returns:
         (write_edge_configs, nodes_to_write):
@@ -845,12 +851,8 @@ def _gather_new_external_subcircuits(
 
     write_edge_configs = []
     for name, edge in circuit.edges.items():
-        L.debug("GATHER-ALL: edge=%s, src_type=%s, target=%s, target_in_mapping=%s",
-                name, edge.source.type, edge.target.name, edge.target.name in id_mapping)
         if edge.source.type != "virtual" and edge.target.name in id_mapping:
             wanted_src_ids = circuit.nodes[edge.source.name].ids()
-            L.debug("GATHER: edge=%s, source=%s, target=%s, all_src_ids=%s",
-                    name, edge.source.name, edge.target.name, wanted_src_ids.tolist())
 
             if edge.source.name in id_mapping:
                 wanted_src_ids = wanted_src_ids[
@@ -912,6 +914,9 @@ def _gather_new_external_subcircuits(
                     [existing_mapping, wanted_src_ids.loc[~is_existing]], axis=0
                 )
             else:
+                pop_offset = (external_id_offset or {}).get(new_source_pop_name, 0)
+                if pop_offset:
+                    wanted_src_ids[NEW_IDS] = wanted_src_ids[NEW_IDS] + pop_offset
                 id_mapping[new_source_pop_name] = wanted_src_ids
 
             write_edge_config = WriteEdgeConfig(
@@ -1397,10 +1402,17 @@ def split_subcircuit(
         )
 
         # Phase B: create new externals from biophysical populations now outside subcircuit
-        # Give _gather a clean id_mapping without filter's external entries
+        # Give _gather a clean id_mapping without filter's external entries.
+        # Pass offset so new_ids continue after filter's max for overlapping populations.
         gather_id_mapping = {k: v for k, v in id_mapping.items() if not k.startswith("external_")}
         gather_node_pop_name_mapping = {
             k: v for k, v in node_pop_name_mapping.items() if not k.startswith("external_")
+        }
+        # Compute per-population offset: new_ids continue after filter's max
+        external_offsets = {
+            k: int(v[NEW_IDS].max()) + 1
+            for k, v in id_mapping.items()
+            if k.startswith("external_")
         }
         write_edge_configs_b, nodes_to_write_b = _gather_new_external_subcircuits(
             output,
@@ -1409,30 +1421,19 @@ def split_subcircuit(
             gather_node_pop_name_mapping,
             existing_node_pop_names,
             existing_edge_pop_names,
+            external_id_offset=external_offsets,
         )
 
-        # Merge: for overlapping populations, renumber gather's new_ids and combine
+        # Merge: gather's external populations are already offset.
+        # Move them to id_mapping_secondary (for serialization) or main id_mapping.
         id_mapping_secondary = {}
         for pop_name in list(gather_id_mapping.keys()):
             if not pop_name.startswith("external_"):
                 continue
             gather_df = gather_id_mapping[pop_name]
-            L.debug("MERGE: pop=%s, in id_mapping=%s, gather new_ids=%s",
-                    pop_name, pop_name in id_mapping, gather_df[NEW_IDS].tolist())
             if pop_name in id_mapping:
-                # Overlapping: renumber gather's IDs after filter's max
-                offset = int(id_mapping[pop_name][NEW_IDS].max()) + 1
-                gather_df[NEW_IDS] = gather_df[NEW_IDS] + offset
+                # Overlapping: store as secondary (already offset)
                 id_mapping_secondary[pop_name] = gather_df
-                # Update src_mapping in gather's WriteEdgeConfigs
-                for cfg in write_edge_configs_b:
-                    if cfg.src_node_name == pop_name:
-                        new_mappings = []
-                        for m in cfg.src_mapping:
-                            m_copy = m.copy()
-                            m_copy[NEW_IDS] = m_copy[NEW_IDS] + offset
-                            new_mappings.append(m_copy)
-                        cfg.src_mapping = new_mappings
                 # Append parent name
                 if pop_name in gather_node_pop_name_mapping:
                     for parent in gather_node_pop_name_mapping[pop_name]:
@@ -1482,15 +1483,6 @@ def split_subcircuit(
         node_pop_name_mapping,
         id_mapping_secondary if create_external else None,
     )
-    # Temporary debug assert
-    if create_external and "external_A" in id_mapping_secondary:
-        _sec = id_mapping_secondary["external_A"]
-        _pri = id_mapping["external_A"]
-        assert int(_sec[NEW_IDS].max()) == int(_pri[NEW_IDS].max()) + len(_sec), (
-            f"Secondary new_id mismatch: sec_max={int(_sec[NEW_IDS].max())}, "
-            f"pri_max={int(_pri[NEW_IDS].max())}, sec_len={len(_sec)}"
-        )
-
     config = copy.deepcopy(circuit.config)
 
     node_sets = _update_node_sets(utils.load_json(config["node_sets_file"]), id_mapping)

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -1209,24 +1209,25 @@ def _mapping_to_parent_dict(id_mapping, node_pop_name_mapping):
     return mapping
 
 
-def _make_parent_the_original_mapping(this_mapping):
-    for this_pop in this_mapping.keys():
-        this_mapping[this_pop][ORIG_IDS] = this_mapping[this_pop][PARENT_IDS]
-        this_mapping[this_pop][ORIG_NAME] = this_mapping[this_pop][PARENT_NAME]
+def _set_original_ids(this_mapping: dict, parent_mapping: dict | None) -> None:
+    """Set original_id and original_name for each population in the mapping.
 
-
-def _add_mapping_to_original(this_mapping, parent_mapping):
-    for this_pop in this_mapping.keys():
-        parent_pop = this_mapping[this_pop][PARENT_NAME]
-
-        backwards_mapped = pd.Series(
-            parent_mapping[parent_pop][ORIG_IDS], index=parent_mapping[parent_pop][NEW_IDS]
-        )
-        orig_ids = backwards_mapped[this_mapping[this_pop][PARENT_IDS]]
-        orig_name = parent_mapping[parent_pop][ORIG_NAME]
-
-        this_mapping[this_pop][ORIG_IDS] = orig_ids.to_list()
-        this_mapping[this_pop][ORIG_NAME] = orig_name
+    If parent_mapping is None (parent is the root circuit), original_id is
+    copied from parent_id. Otherwise, original_id is traced back through the
+    parent's mapping to the root circuit.
+    """
+    for entry in this_mapping.values():
+        if parent_mapping is None:
+            entry[ORIG_IDS] = entry[PARENT_IDS]
+            entry[ORIG_NAME] = entry[PARENT_NAME]
+        else:
+            parent_pop = entry[PARENT_NAME]
+            backwards_mapped = pd.Series(
+                parent_mapping[parent_pop][ORIG_IDS],
+                index=parent_mapping[parent_pop][NEW_IDS],
+            )
+            entry[ORIG_IDS] = backwards_mapped[entry[PARENT_IDS]].to_list()
+            entry[ORIG_NAME] = parent_mapping[parent_pop][ORIG_NAME]
 
 
 def _write_mapping(output, parent_circ, id_mapping, node_pop_name_mapping):
@@ -1234,14 +1235,14 @@ def _write_mapping(output, parent_circ, id_mapping, node_pop_name_mapping):
     this_mapping = _mapping_to_parent_dict(id_mapping, node_pop_name_mapping)
 
     provenance = parent_circ.config.get("components", {}).get("provenance", {})
-    if "id_mapping" in provenance:
-        # Currently, bluepysnap does not seem to resolve $BASE_DIR for entries in "provenance".
-        # Therefore I decided to not prepend it and just assume the file exists near the circuit config.
+    # Currently, bluepysnap does not resolve $BASE_DIR for provenance entries,
+    # so assume the mapping file is relative to the circuit config.
+    parent_mapping = None
+    if mapping_path := provenance.get("id_mapping"):
         parent_root = Path(parent_circ._circuit_config_path).parent
-        parent_mapping = utils.load_json(parent_root / provenance["id_mapping"])
-        _add_mapping_to_original(this_mapping, parent_mapping)
-    else:
-        _make_parent_the_original_mapping(this_mapping)
+        parent_mapping = utils.load_json(parent_root / mapping_path)
+
+    _set_original_ids(this_mapping, parent_mapping)
 
     mapping_fn = "id_mapping.json"
     utils.dump_json(output / mapping_fn, this_mapping)

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -798,11 +798,17 @@ def _orchestrate_write_subcircuit_edges(write_edge_configs: list[WriteEdgeConfig
             write_edge_config=write_edge_config, edge_mappings=edge_mappings
         )
         key = (str(output_path), write_edge_config.dst_edge_name)
-        index_info[key] = (output_path, write_edge_config.dst_edge_name, edge_count, sgid_count, tgid_count)
+        index_info[key] = (
+            output_path,
+            write_edge_config.dst_edge_name,
+            edge_count,
+            sgid_count,
+            tgid_count,
+        )
         new_edges_files[write_edge_config.dst_edge_name] = output_path
 
     # Write indexes after all edges are written (handles append case)
-    for (output_path, dst_edge_name, edge_count, sgid_count, tgid_count) in index_info.values():
+    for output_path, dst_edge_name, edge_count, sgid_count, tgid_count in index_info.values():
         if edge_count > 0:
             _write_indexes(
                 edge_file_name=output_path,
@@ -946,8 +952,7 @@ def _gather_new_external_subcircuit(
                 # Check if existing mapping came from a different source population
                 existing_parent = node_pop_name_mapping.get(new_source_pop_name)
                 different_source = (
-                    existing_parent is not None
-                    and existing_parent != edge.source.name
+                    existing_parent is not None and existing_parent != edge.source.name
                 )
 
                 if different_source:
@@ -1015,16 +1020,20 @@ def _gather_new_external_subcircuit(
             if new_source_pop_name in id_mapping_secondary:
                 # Mixed source: only write the secondary (new biophysical) nodes.
                 # The primary (carried-over external) nodes are handled by _filter.
-                nodes_to_write[new_source_pop_name] = [(
-                    node_pop_name_mapping_secondary[new_source_pop_name],
-                    id_mapping_secondary[new_source_pop_name].index.to_numpy(),
-                )]
+                nodes_to_write[new_source_pop_name] = [
+                    (
+                        node_pop_name_mapping_secondary[new_source_pop_name],
+                        id_mapping_secondary[new_source_pop_name].index.to_numpy(),
+                    )
+                ]
             else:
                 # Single source: all nodes come from _gather
-                nodes_to_write[new_source_pop_name] = [(
-                    edge.source.name,
-                    id_mapping[new_source_pop_name].index.to_numpy(),
-                )]
+                nodes_to_write[new_source_pop_name] = [
+                    (
+                        edge.source.name,
+                        id_mapping[new_source_pop_name].index.to_numpy(),
+                    )
+                ]
 
     return write_edge_configs, nodes_to_write, id_mapping_secondary, node_pop_name_mapping_secondary
 
@@ -1297,8 +1306,12 @@ def _set_original_ids(this_mapping: dict, parent_mapping: dict | None) -> None:
 
 
 def _write_mapping(
-    output, parent_circ, id_mapping, node_pop_name_mapping,
-    id_mapping_secondary=None, node_pop_name_mapping_secondary=None,
+    output,
+    parent_circ,
+    id_mapping,
+    node_pop_name_mapping,
+    id_mapping_secondary=None,
+    node_pop_name_mapping_secondary=None,
 ):
     """write the id mappings between the old and new populations for future analysis"""
     if id_mapping_secondary is None:
@@ -1336,10 +1349,21 @@ def _write_mapping(
             )
             # Combine new_ids (primary first, secondary appends)
             primary_entry[NEW_IDS] = primary_entry[NEW_IDS] + sec_entry[NEW_IDS]
+            # Combine original_ids (same original_name, just append)
+            primary_entry[ORIG_IDS] = primary_entry[ORIG_IDS] + sec_entry[ORIG_IDS]
             # Add parent2_* fields
             primary_entry["parent2_id"] = sec_entry[PARENT_IDS]
             primary_entry["parent2_name"] = sec_entry[PARENT_NAME]
-            primary_entry["original2_id"] = sec_entry[ORIG_IDS]
+
+            # Invariant: parent_id + parent2_id lengths == new_id == original_id
+            n_total = len(primary_entry[NEW_IDS])
+            n_parents = len(primary_entry[PARENT_IDS]) + len(primary_entry["parent2_id"])
+            assert n_parents == n_total == len(primary_entry[ORIG_IDS]), (
+                f"Length mismatch for merged population '{pop_name}': "
+                f"parent_id({len(primary_entry[PARENT_IDS])}) + "
+                f"parent2_id({len(primary_entry['parent2_id'])}) = {n_parents}, "
+                f"new_id={n_total}, original_id={len(primary_entry[ORIG_IDS])}"
+            )
 
     mapping_fn = "id_mapping.json"
     utils.dump_json(output / mapping_fn, this_mapping)
@@ -1446,7 +1470,12 @@ def split_subcircuit(
         )
 
         # Phase B: create new externals from biophysical populations now outside subcircuit
-        write_edge_configs_b, nodes_to_write_b, id_mapping_secondary, node_pop_name_mapping_secondary = _gather_new_external_subcircuit(
+        (
+            write_edge_configs_b,
+            nodes_to_write_b,
+            id_mapping_secondary,
+            node_pop_name_mapping_secondary,
+        ) = _gather_new_external_subcircuit(
             output,
             circuit,
             id_mapping,
@@ -1482,8 +1511,12 @@ def split_subcircuit(
         new_edge_files.update(new_virtual_edge_files)
 
     mapping_fn = _write_mapping(
-        output, circuit, id_mapping, node_pop_name_mapping,
-        id_mapping_secondary, node_pop_name_mapping_secondary,
+        output,
+        circuit,
+        id_mapping,
+        node_pop_name_mapping,
+        id_mapping_secondary,
+        node_pop_name_mapping_secondary,
     )
 
     config = copy.deepcopy(circuit.config)

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -985,6 +985,7 @@ def _write_subcircuit_virtual(
             edge.source.type == "virtual"
             and edge.target.name in id_mapping
             and edge.source.name not in list_of_sources_to_ignore
+            and not edge.source.name.startswith("external_")
         )
     }
 

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -452,15 +452,6 @@ def _write_masked_edges(
         _populate_edge_group(orig_edges[GROUP_NAME], new_edges[GROUP_NAME], sl, mask, overrides)
 
 
-def _write_indexes(
-    edge_file_name: str | Path, new_pop_name: str, source_node_count: int, target_node_count: int
-):
-    """ibid"""
-    libsonata.EdgePopulation.write_indices(
-        str(edge_file_name), new_pop_name, source_node_count, target_node_count
-    )
-
-
 def _check_all_edges_used(h5in, written_edges):
     """Verify that the number of written edges matches the number of initial edges."""
     orig_edges = h5in["edges"][_get_unique_population(h5in["edges"])]
@@ -501,8 +492,8 @@ def _write_edges(
 
             # after the file is closed, it's indexed if valid, or it's removed if empty
             if edge_count > 0:
-                _write_indexes(
-                    write_edge_config.output_path,
+                libsonata.EdgePopulation.write_indices(
+                    str(write_edge_config.output_path),
                     edge_pop_name,
                     write_edge_config.source_node_count,
                     write_edge_config.target_node_count,
@@ -768,11 +759,11 @@ def _orchestrate_write_subcircuit_edges(write_edge_configs: list[WriteEdgeConfig
         )
 
         if edge_count > 0:
-            _write_indexes(
-                edge_file_name=output_path,
-                new_pop_name=write_edge_config.dst_edge_name,
-                source_node_count=write_edge_config.source_node_count,
-                target_node_count=write_edge_config.target_node_count,
+            libsonata.EdgePopulation.write_indices(
+                str(output_path),
+                write_edge_config.dst_edge_name,
+                write_edge_config.source_node_count,
+                write_edge_config.target_node_count,
             )
 
         new_edges_files[write_edge_config.dst_edge_name] = output_path

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -48,21 +48,24 @@ ORIG_NAME = "original_name"
 
 @dataclass
 class WriteEdgeConfig:
-    input_path: str | Path
+    input_path: str | Path | list[str | Path]
     output_path: str | Path
     src_node_name: str
     dst_node_name: str
-    src_edge_name: str
+    src_edge_name: str | list[str]
     dst_edge_name: str
-    src_mapping: pd.DataFrame
+    src_mapping: pd.DataFrame | list[pd.DataFrame]
     dst_mapping: pd.DataFrame
     h5_read_chunk_size: int | None = None
     edge_type: type[bytes] | None = None
 
     def __post_init__(self):
-        self.input_path = (
-            Path(self.input_path) if isinstance(self.input_path, str) else self.input_path
-        )
+        # Normalize to lists for uniform processing
+        if not isinstance(self.input_path, list):
+            self.input_path = [self.input_path]
+            self.src_edge_name = [self.src_edge_name]
+            self.src_mapping = [self.src_mapping]
+        self.input_path = [Path(p) if isinstance(p, str) else p for p in self.input_path]
         self.output_path = (
             Path(self.output_path) if isinstance(self.output_path, str) else self.output_path
         )
@@ -226,9 +229,6 @@ def _populate_edge_group(orig_group, new_group, sl, mask, overrides):
 def _finalize_edges(new_edges):
     """add datasets for `new_edges` so they fulfil SONATA spec"""
     edge_count = len(new_edges["source_node_id"])
-    for name in ("edge_type_id", "edge_group_id", "edge_group_index"):
-        if name in new_edges:
-            del new_edges[name]
     new_edges["edge_type_id"] = np.full(edge_count, -1)
     new_edges["edge_group_id"] = np.full(edge_count, 0)
     new_edges["edge_group_index"] = np.arange(edge_count, dtype=np.uint64)
@@ -240,23 +240,24 @@ def _h5_get_read_chunk_size():
 
 
 def _copy_filtered_edges(
-    h5in: h5py.File,
     h5out: h5py.File,
     write_edge_config: WriteEdgeConfig,
     edge_mappings: dict[str, tuple[pd.DataFrame, str]] = None,
 ):
     """
-    Copy and filter edge datasets from an input HDF5 file to an output HDF5 file.
+    Copy and filter edge datasets from input HDF5 file(s) to an output HDF5 file.
+
+    Supports multiple input sources (input_path/src_edge_name/src_mapping lists)
+    which are processed sequentially into a single output edge population.
 
     This function:
-        - Reads the source edge population in chunks.
+        - Reads the source edge population(s) in chunks.
         - Filters edges based on source and target node mappings.
         - Copies source/target node IDs and all associated datasets.
         - Initializes and populates new edge groups, preserving attributes.
         - Raises errors if invalid IDs or unsupported groups (e.g., @library) are encountered.
 
     Args:
-        h5in (h5py.File): Input HDF5 file containing original edges.
         h5out (h5py.File): Output HDF5 file to store filtered edges.
         write_edge_config (WriteEdgeConfig): Configuration specifying
             source/target populations, edge names, mappings, and read chunk size.
@@ -269,25 +270,19 @@ def _copy_filtered_edges(
         - Supports appendable datasets; existing datasets will raise an error if re-created.
         - Processing is chunked to handle large edge populations efficiently.
     """
-    # extract values
     h5_read_chunk_size = (
         write_edge_config.h5_read_chunk_size
         if write_edge_config.h5_read_chunk_size is not None
         else _h5_get_read_chunk_size()
     )
     is_neuroglial = write_edge_config.edge_type == "synapse_astrocyte"
-    # get groups
-    orig_edges = h5in["edges"][write_edge_config.src_edge_name]
-    orig_group = _get_unique_group(orig_edges)
 
-    edge_path = "edges/" + write_edge_config.dst_edge_name
-    if edge_path in h5out:
-        # Appending to an existing edge population
-        new_edges = h5out[edge_path]
-        new_group = new_edges[GROUP_NAME]
-    else:
-        # Creating a new edge population
-        new_edges = h5out.create_group(edge_path)
+    # Create output edge group (once, using first input as template)
+    with h5py.File(write_edge_config.input_path[0], "r") as h5_first:
+        first_orig_edges = h5_first["edges"][write_edge_config.src_edge_name[0]]
+        orig_group = _get_unique_group(first_orig_edges)
+
+        new_edges = h5out.create_group("edges/" + write_edge_config.dst_edge_name)
         new_group = new_edges.create_group(GROUP_NAME)
 
         hdf5.create_appendable_dataset(new_edges, "source_node_id", np.uint64)
@@ -298,69 +293,70 @@ def _copy_filtered_edges(
 
         additional_attrs = {}
         if is_neuroglial:
-            # find new name of synapse_edge_pop
-            src_syn_edge_pop = orig_edges[GROUP_NAME]["synapse_id"].attrs["edge_population"]
+            src_syn_edge_pop = orig_group["synapse_id"].attrs["edge_population"]
             _, dst_syn_edge_pop = edge_mappings[src_syn_edge_pop]
-            # create dataset and add correct attr
             additional_attrs["synapse_id"] = {"edge_population": dst_syn_edge_pop}
 
         _init_edge_group(orig_group, new_group, additional_attrs)
 
-    sgids_new = write_edge_config.src_mapping.index.to_numpy()
+    # Process each input source
     tgids_new = write_edge_config.dst_mapping.index.to_numpy()
-    assert (sgids_new >= 0).all(), "Source population ids must be positive."
     assert (tgids_new >= 0).all(), "Target population ids must be positive."
 
-    total_chunks = math.ceil(len(orig_edges["source_node_id"]) / h5_read_chunk_size)
-    L.debug(
-        "Processing %s edges in %s chunks of size %s [src_edge_name=%s]",
-        len(orig_edges["source_node_id"]),
-        total_chunks,
-        h5_read_chunk_size,
+    for input_path, src_edge_name, src_mapping in zip(
+        write_edge_config.input_path,
         write_edge_config.src_edge_name,
-    )
+        write_edge_config.src_mapping,
+    ):
+        sgids_new = src_mapping.index.to_numpy()
+        assert (sgids_new >= 0).all(), "Source population ids must be positive."
 
-    sl_and_masks = _compute_chunks_and_masks(
-        orig_edges=orig_edges,
-        sgids_new=sgids_new,
-        tgids_new=tgids_new,
-        h5_read_chunk_size=h5_read_chunk_size,
-        edge_mappings=edge_mappings,
-        is_neuroglial=is_neuroglial,
-    )
+        with h5py.File(input_path, "r") as h5in:
+            orig_edges = h5in["edges"][src_edge_name]
 
-    if edge_mappings is not None:
-        offset = new_edges["source_node_id"].shape[0]
-        if offset != 0 and is_neuroglial:
-            raise RuntimeError(
-                "Cannot append neuroglial edges when edge_mappings is enabled and the destination "
-                f"already contains {offset} edges. The current implementation only supports edges "
-                "created in a single pass and does not capture cross-generation connections "
-                "(old astrocyte -> new neuron or new astrocyte -> old neuron). "
-                "Only new->new connections would be handled correctly. "
-                "Appending is therefore blocked as a safety safeguard."
+            total_chunks = math.ceil(len(orig_edges["source_node_id"]) / h5_read_chunk_size)
+            L.debug(
+                "Processing %s edges in %s chunks of size %s [src_edge_name=%s]",
+                len(orig_edges["source_node_id"]),
+                total_chunks,
+                h5_read_chunk_size,
+                src_edge_name,
             )
 
-        assert write_edge_config.src_edge_name not in edge_mappings, (
-            f"Source edge population '{write_edge_config.src_edge_name}' "
-            "already exists in edge_mappings. "
-            "Cannot overwrite an existing mapping; check your inputs or "
-            "ensure edge populations are unique."
-        )
-        edge_mappings[write_edge_config.src_edge_name] = (
-            _compute_edge_mapping(sl_and_masks=sl_and_masks, offset=offset),
-            write_edge_config.dst_edge_name,
-        )
+            sl_and_masks = _compute_chunks_and_masks(
+                orig_edges=orig_edges,
+                sgids_new=sgids_new,
+                tgids_new=tgids_new,
+                h5_read_chunk_size=h5_read_chunk_size,
+                edge_mappings=edge_mappings,
+                is_neuroglial=is_neuroglial,
+            )
 
-    _write_masked_edges(
-        sl_and_masks=sl_and_masks,
-        new_edges=new_edges,
-        orig_edges=orig_edges,
-        src_mapping=write_edge_config.src_mapping,
-        dst_mapping=write_edge_config.dst_mapping,
-        edge_mappings=edge_mappings,
-        is_neuroglial=is_neuroglial,
-    )
+            if edge_mappings is not None:
+                offset = new_edges["source_node_id"].shape[0]
+                if offset != 0 and is_neuroglial:
+                    raise RuntimeError(
+                        "Cannot append neuroglial edges when edge_mappings is enabled and the "
+                        f"destination already contains {offset} edges."
+                    )
+
+                assert src_edge_name not in edge_mappings, (
+                    f"Source edge population '{src_edge_name}' already exists in edge_mappings."
+                )
+                edge_mappings[src_edge_name] = (
+                    _compute_edge_mapping(sl_and_masks=sl_and_masks, offset=offset),
+                    write_edge_config.dst_edge_name,
+                )
+
+            _write_masked_edges(
+                sl_and_masks=sl_and_masks,
+                new_edges=new_edges,
+                orig_edges=orig_edges,
+                src_mapping=src_mapping,
+                dst_mapping=write_edge_config.dst_mapping,
+                edge_mappings=edge_mappings,
+                is_neuroglial=is_neuroglial,
+            )
 
     L.debug("Finalize edges")
     _finalize_edges(new_edges)
@@ -511,7 +507,7 @@ def _write_edges(
 
             L.debug("Writing to  %s", write_edge_config.output_path)
             with h5py.File(write_edge_config.output_path, "w") as h5out:
-                _copy_filtered_edges(h5in=h5in, h5out=h5out, write_edge_config=write_edge_config)
+                _copy_filtered_edges(h5out=h5out, write_edge_config=write_edge_config)
                 edge_count, sgid_count, tgid_count = _get_node_counts(
                     h5out, edge_pop_name, id_mapping[src_node_pop], id_mapping[dst_node_pop]
                 )
@@ -688,39 +684,37 @@ def _write_subcircuit_edges(
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with h5py.File(write_edge_config.input_path, "r") as h5in:
-        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
-        is_file_empty = False
+    is_file_empty = False
+    with h5py.File(output_path, "a") as h5out:
+        _copy_filtered_edges(
+            h5out=h5out,
+            write_edge_config=write_edge_config,
+            edge_mappings=edge_mappings,
+        )
 
-        with h5py.File(output_path, "a") as h5out:
-            _copy_filtered_edges(
-                h5in=h5in,
-                h5out=h5out,
-                write_edge_config=write_edge_config,
-                edge_mappings=edge_mappings,
-            )
+        # Use combined src_mapping for node count (covers all inputs)
+        combined_src_mapping = pd.concat(write_edge_config.src_mapping)
+        edge_count, sgid_count, tgid_count = _get_node_counts(
+            h5out=h5out,
+            new_edge_pop_name=write_edge_config.dst_edge_name,
+            src_mapping=combined_src_mapping,
+            dst_mapping=write_edge_config.dst_mapping,
+        )
 
-            edge_count, sgid_count, tgid_count = _get_node_counts(
-                h5out=h5out,
-                new_edge_pop_name=write_edge_config.dst_edge_name,
-                src_mapping=write_edge_config.src_mapping,
-                dst_mapping=write_edge_config.dst_mapping,
-            )
+        if edge_count == 0:
+            del h5out[f"/edges/{write_edge_config.dst_edge_name}"]
+            is_file_empty = len(h5out["/edges"]) == 0
 
-            if edge_count == 0:
-                del h5out[f"/edges/{write_edge_config.dst_edge_name}"]
-                is_file_empty = len(h5out["/edges"]) == 0
+    # after the h5 file is closed, it's indexed if valid, or it's removed if empty
+    if edge_count > 0:
+        L.debug("Wrote %s edges to %s", edge_count, output_path)
+    elif is_file_empty:
+        Path(output_path).unlink(missing_ok=True)
+        output_path = DELETED_EMPTY_EDGES_FILE
+    else:  # population empty, but not file
+        output_path = DELETED_EMPTY_EDGES_POPULATION
 
-        # after the h5 file is closed, it's indexed if valid, or it's removed if empty
-        if edge_count > 0:
-            L.debug("Wrote %s edges to %s", edge_count, output_path)
-        elif is_file_empty:
-            Path(output_path).unlink(missing_ok=True)
-            output_path = DELETED_EMPTY_EDGES_FILE
-        else:  # population empty, but not file
-            output_path = DELETED_EMPTY_EDGES_POPULATION
-
-        return output_path, edge_count, sgid_count, tgid_count
+    return output_path, edge_count, sgid_count, tgid_count
 
 
 def _get_storage_path(edge):
@@ -791,34 +785,20 @@ def _orchestrate_write_subcircuit_edges(write_edge_configs: list[WriteEdgeConfig
         write_edge_configs, key=lambda cfg: cfg.edge_type == "synapse_astrocyte"
     )
 
-    # Track the last write result per (output_path, dst_edge_name) for indexing
-    index_info = {}
     for write_edge_config in write_edge_configs_sorted:
         output_path, edge_count, sgid_count, tgid_count = _write_subcircuit_edges(
             write_edge_config=write_edge_config, edge_mappings=edge_mappings
         )
-        key = (str(output_path), write_edge_config.dst_edge_name)
-        index_info[key] = (
-            output_path,
-            write_edge_config.dst_edge_name,
-            edge_count,
-            sgid_count,
-            tgid_count,
-        )
-        new_edges_files[write_edge_config.dst_edge_name] = output_path
 
-    # Write indexes after all edges are written (handles append case)
-    for output_path, dst_edge_name, edge_count, sgid_count, tgid_count in index_info.values():
         if edge_count > 0:
             _write_indexes(
                 edge_file_name=output_path,
-                new_pop_name=dst_edge_name,
+                new_pop_name=write_edge_config.dst_edge_name,
                 source_node_count=sgid_count,
                 target_node_count=tgid_count,
             )
-        elif output_path == DELETED_EMPTY_EDGES_FILE:
-            pass  # already deleted
-        # DELETED_EMPTY_EDGES_POPULATION: nothing to do
+
+        new_edges_files[write_edge_config.dst_edge_name] = output_path
 
     return new_edges_files
 
@@ -1484,15 +1464,20 @@ def split_subcircuit(
             existing_edge_pop_names,
         )
 
-        # Merge: concatenate edge configs, merge nodes_to_write lists
-        # Align output paths: if gather has same dst_edge_name as filter,
-        # use filter's output_path so both write to the same file.
-        filter_paths = {cfg.dst_edge_name: cfg.output_path for cfg in write_edge_configs_a}
-        for cfg in write_edge_configs_b:
-            if cfg.dst_edge_name in filter_paths:
-                cfg.output_path = filter_paths[cfg.dst_edge_name]
+        # Merge edge configs: combine configs with same dst_edge_name into
+        # a single multi-input config; leave others as-is.
+        filter_configs_by_name = {cfg.dst_edge_name: cfg for cfg in write_edge_configs_a}
+        merged_edge_configs = list(write_edge_configs_a)
+        for cfg_b in write_edge_configs_b:
+            if cfg_b.dst_edge_name in filter_configs_by_name:
+                # Merge into existing config (append inputs)
+                cfg_a = filter_configs_by_name[cfg_b.dst_edge_name]
+                cfg_a.input_path = cfg_a.input_path + cfg_b.input_path
+                cfg_a.src_edge_name = cfg_a.src_edge_name + cfg_b.src_edge_name
+                cfg_a.src_mapping = cfg_a.src_mapping + cfg_b.src_mapping
+            else:
+                merged_edge_configs.append(cfg_b)
 
-        merged_edge_configs = write_edge_configs_a + write_edge_configs_b
         merged_nodes_to_write = dict(nodes_to_write_a)
         for pop_name, sources in nodes_to_write_b.items():
             if pop_name in merged_nodes_to_write:

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -946,18 +946,15 @@ def _write_subcircuit_external(
             )
             write_edge_configs.append(write_edge_config)
 
-            new_nodes[new_source_pop_name] = (
-                edge.source.name,
-                wanted_src_ids.index.to_numpy(),
-            )
+            new_nodes[new_source_pop_name] = edge.source.name
 
     new_edges_files = _orchestrate_write_subcircuit_edges(write_edge_configs=write_edge_configs)
 
     new_node_files = {}
     # write new virtual nodes from originally non-virtual populations
-    for population_name, id_tuple in new_nodes.items():
-        # Get all properties of the subset of the node population that is relevant
-        orig_population_name, ids = id_tuple
+    for population_name, orig_population_name in new_nodes.items():
+        # Use the accumulated id_mapping (which merges IDs across all edges)
+        ids = id_mapping[population_name].index.to_numpy()
         df = circuit.nodes[orig_population_name].get(ids).reset_index(drop=True)
         nodes_path = Path(output) / population_name / "nodes.h5"
         nodes_path.parent.mkdir(parents=True, exist_ok=True)

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -651,9 +651,13 @@ def _write_subcircuit_edges(
 ):
     """Write a filtered edge population to an HDF5 file.
 
+    If the population has no edges after filtering, it is removed from the file.
+    If the file becomes empty as a result, the file itself is deleted.
+
     Returns:
-        (output_path, edge_count): the path written to (or sentinel if empty),
-        and the number of edges written.
+        (output_path, edge_count): the path written to, and the number of edges.
+        output_path may be DELETED_EMPTY_EDGES_FILE (file removed) or
+        DELETED_EMPTY_EDGES_POPULATION (population removed, file kept).
     """
     output_path = write_edge_config.output_path
 
@@ -807,7 +811,7 @@ def _get_subcircuit_external_ids(all_sgids, all_tgids, wanted_src_ids, wanted_ds
     return ret.sort_index()
 
 
-def _gather_new_external_subcircuit(
+def _gather_new_external_subcircuits(
     output,
     circuit,
     id_mapping,
@@ -839,7 +843,6 @@ def _gather_new_external_subcircuit(
 
     nodes_to_write = {}
     id_mapping_secondary = {}
-    node_pop_name_mapping_secondary = {}
 
     write_edge_configs = []
     for name, edge in circuit.edges.items():
@@ -880,7 +883,7 @@ def _gather_new_external_subcircuit(
                 L.debug("%s already exists as an node population", new_source_pop_name)
                 new_source_pop_name = "external_" + new_source_pop_name
             if new_source_pop_name not in node_pop_name_mapping:
-                node_pop_name_mapping[new_source_pop_name] = edge.source.name
+                node_pop_name_mapping[new_source_pop_name] = [edge.source.name]
 
             output_path = output / (new_name + ".h5")
             output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -898,10 +901,9 @@ def _gather_new_external_subcircuit(
                 existing_mapping = id_mapping[new_source_pop_name]
 
                 # Check if existing mapping came from a different source population
-                existing_parent = node_pop_name_mapping.get(new_source_pop_name)
-                different_source = (
-                    existing_parent is not None and existing_parent != edge.source.name
-                )
+                # Compare against the first (primary) parent only
+                existing_parents = node_pop_name_mapping.get(new_source_pop_name, [])
+                different_source = existing_parents and existing_parents[0] != edge.source.name
 
                 if different_source:
                     # Nodes from a different parent population — store separately
@@ -929,7 +931,8 @@ def _gather_new_external_subcircuit(
                         new_ids = np.arange(len(wanted_src_ids)) + int(max_existing_id) + 1
                         wanted_src_ids[NEW_IDS] = new_ids
                         id_mapping_secondary[new_source_pop_name] = wanted_src_ids
-                    node_pop_name_mapping_secondary[new_source_pop_name] = edge.source.name
+                    if edge.source.name not in node_pop_name_mapping[new_source_pop_name]:
+                        node_pop_name_mapping[new_source_pop_name].append(edge.source.name)
                 else:
                     is_existing = _isin(wanted_src_ids.index, existing_mapping.index)
                     wanted_src_ids.loc[is_existing] = existing_mapping.loc[
@@ -970,7 +973,7 @@ def _gather_new_external_subcircuit(
                 # The primary (carried-over external) nodes are handled by _filter.
                 nodes_to_write[new_source_pop_name] = [
                     (
-                        node_pop_name_mapping_secondary[new_source_pop_name],
+                        edge.source.name,
                         id_mapping_secondary[new_source_pop_name].index.to_numpy(),
                     )
                 ]
@@ -983,7 +986,7 @@ def _gather_new_external_subcircuit(
                     )
                 ]
 
-    return write_edge_configs, nodes_to_write, id_mapping_secondary, node_pop_name_mapping_secondary
+    return write_edge_configs, nodes_to_write, id_mapping_secondary
 
 
 def _filter_virtual_typed_subcircuit(
@@ -1050,7 +1053,7 @@ def _filter_virtual_typed_subcircuit(
     # update the mappings with the selected source nodes
     for name, ids in pop_used_source_node_ids.items():
         id_mapping[name] = pd.DataFrame({NEW_IDS: range(len(ids))}, index=ids)
-        node_pop_name_mapping[name] = name
+        node_pop_name_mapping[name] = [name]
 
     write_edge_configs = [
         WriteEdgeConfig(
@@ -1221,14 +1224,35 @@ def _update_node_sets(node_sets, id_mapping):
     return ret
 
 
-def _mapping_to_parent_dict(id_mapping, node_pop_name_mapping):
+def _mapping_to_parent_dict(id_mapping, node_pop_name_mapping, id_mapping_secondary=None):
+    """Build the serializable mapping dict from id_mapping and parent names.
+
+    Handles multiple parents per population: first parent uses parent_name/parent_id,
+    subsequent parents use parent2_name/parent2_id, parent3_name/parent3_id, etc.
+    """
+    if id_mapping_secondary is None:
+        id_mapping_secondary = {}
+
     mapping = {}
     for population, df in id_mapping.items():
-        mapping[population] = {
+        parent_names = node_pop_name_mapping[population]
+
+        entry = {
             PARENT_IDS: df.index.to_list(),
             NEW_IDS: df[NEW_IDS].to_list(),
-            PARENT_NAME: node_pop_name_mapping[population],
+            PARENT_NAME: parent_names[0],
         }
+
+        # Add secondary parent(s) if present
+        if population in id_mapping_secondary:
+            sec_df = id_mapping_secondary[population]
+            entry[NEW_IDS] = entry[NEW_IDS] + sec_df[NEW_IDS].to_list()
+            for i, parent_name in enumerate(parent_names[1:], start=2):
+                suffix = str(i)
+                entry[f"parent{suffix}_id"] = sec_df.index.to_list()
+                entry[f"parent{suffix}_name"] = parent_name
+
+        mapping[population] = entry
     return mapping
 
 
@@ -1238,19 +1262,51 @@ def _set_original_ids(this_mapping: dict, parent_mapping: dict | None) -> None:
     If parent_mapping is None (parent is the root circuit), original_id is
     copied from parent_id. Otherwise, original_id is traced back through the
     parent's mapping to the root circuit.
+
+    Handles numbered parent fields (parent2_id/parent2_name, etc.) for
+    populations with multiple parent sources.
     """
     for entry in this_mapping.values():
         if parent_mapping is None:
-            entry[ORIG_IDS] = entry[PARENT_IDS]
+            # Collect all parent_ids across numbered fields
+            all_parent_ids = list(entry[PARENT_IDS])
+            for i in range(2, 100):
+                key = f"parent{i}_id"
+                if key not in entry:
+                    break
+                all_parent_ids.extend(entry[key])
+            entry[ORIG_IDS] = all_parent_ids
             entry[ORIG_NAME] = entry[PARENT_NAME]
         else:
+            # Resolve primary parent
             parent_pop = entry[PARENT_NAME]
             backwards_mapped = pd.Series(
                 parent_mapping[parent_pop][ORIG_IDS],
                 index=parent_mapping[parent_pop][NEW_IDS],
             )
-            entry[ORIG_IDS] = backwards_mapped[entry[PARENT_IDS]].to_list()
-            entry[ORIG_NAME] = parent_mapping[parent_pop][ORIG_NAME]
+            orig_ids = backwards_mapped[entry[PARENT_IDS]].to_list()
+            orig_name = parent_mapping[parent_pop][ORIG_NAME]
+
+            # Resolve numbered parents
+            for i in range(2, 100):
+                id_key = f"parent{i}_id"
+                name_key = f"parent{i}_name"
+                if id_key not in entry:
+                    break
+                parent_pop_i = entry[name_key]
+                backwards_mapped_i = pd.Series(
+                    parent_mapping[parent_pop_i][ORIG_IDS],
+                    index=parent_mapping[parent_pop_i][NEW_IDS],
+                )
+                orig_ids.extend(backwards_mapped_i[entry[id_key]].to_list())
+                # Assert all parents trace back to the same original
+                assert parent_mapping[parent_pop_i][ORIG_NAME] == orig_name, (
+                    f"Cannot merge: original_name mismatch "
+                    f"{orig_name} vs {parent_mapping[parent_pop_i][ORIG_NAME]}"
+                )
+
+            entry[ORIG_IDS] = orig_ids
+            entry[ORIG_NAME] = orig_name
 
 
 def _write_mapping(
@@ -1259,15 +1315,12 @@ def _write_mapping(
     id_mapping,
     node_pop_name_mapping,
     id_mapping_secondary=None,
-    node_pop_name_mapping_secondary=None,
 ):
-    """write the id mappings between the old and new populations for future analysis"""
+    """Write the id mappings between the old and new populations for future analysis."""
     if id_mapping_secondary is None:
         id_mapping_secondary = {}
-    if node_pop_name_mapping_secondary is None:
-        node_pop_name_mapping_secondary = {}
 
-    this_mapping = _mapping_to_parent_dict(id_mapping, node_pop_name_mapping)
+    this_mapping = _mapping_to_parent_dict(id_mapping, node_pop_name_mapping, id_mapping_secondary)
 
     provenance = parent_circ.config.get("components", {}).get("provenance", {})
     # Currently, bluepysnap does not resolve $BASE_DIR for provenance entries,
@@ -1279,39 +1332,19 @@ def _write_mapping(
 
     _set_original_ids(this_mapping, parent_mapping)
 
-    # Merge secondary mappings (from different parent populations) into parent2_* fields
-    if id_mapping_secondary:
-        secondary_dict = _mapping_to_parent_dict(
-            id_mapping_secondary, node_pop_name_mapping_secondary
+    # Validate length invariants for merged populations
+    for pop_name, entry in this_mapping.items():
+        n_new = len(entry[NEW_IDS])
+        n_parent_ids = len(entry[PARENT_IDS])
+        for i in range(2, 100):
+            key = f"parent{i}_id"
+            if key not in entry:
+                break
+            n_parent_ids += len(entry[key])
+        assert n_parent_ids == n_new == len(entry[ORIG_IDS]), (
+            f"Length mismatch for population '{pop_name}': "
+            f"sum(parent*_id)={n_parent_ids}, new_id={n_new}, original_id={len(entry[ORIG_IDS])}"
         )
-        _set_original_ids(secondary_dict, parent_mapping)
-        for pop_name, sec_entry in secondary_dict.items():
-            assert pop_name in this_mapping, (
-                f"Secondary mapping for '{pop_name}' has no primary entry"
-            )
-            primary_entry = this_mapping[pop_name]
-            # Assert original_name matches
-            assert primary_entry[ORIG_NAME] == sec_entry[ORIG_NAME], (
-                f"Cannot merge external population '{pop_name}': "
-                f"original_name mismatch: {primary_entry[ORIG_NAME]} vs {sec_entry[ORIG_NAME]}"
-            )
-            # Combine new_ids (primary first, secondary appends)
-            primary_entry[NEW_IDS] = primary_entry[NEW_IDS] + sec_entry[NEW_IDS]
-            # Combine original_ids (same original_name, just append)
-            primary_entry[ORIG_IDS] = primary_entry[ORIG_IDS] + sec_entry[ORIG_IDS]
-            # Add parent2_* fields
-            primary_entry["parent2_id"] = sec_entry[PARENT_IDS]
-            primary_entry["parent2_name"] = sec_entry[PARENT_NAME]
-
-            # Invariant: parent_id + parent2_id lengths == new_id == original_id
-            n_total = len(primary_entry[NEW_IDS])
-            n_parents = len(primary_entry[PARENT_IDS]) + len(primary_entry["parent2_id"])
-            assert n_parents == n_total == len(primary_entry[ORIG_IDS]), (
-                f"Length mismatch for merged population '{pop_name}': "
-                f"parent_id({len(primary_entry[PARENT_IDS])}) + "
-                f"parent2_id({len(primary_entry['parent2_id'])}) = {n_parents}, "
-                f"new_id={n_total}, original_id={len(primary_entry[ORIG_IDS])}"
-            )
 
     mapping_fn = "id_mapping.json"
     utils.dump_json(output / mapping_fn, this_mapping)
@@ -1371,10 +1404,10 @@ def split_subcircuit(
 
     id_mapping = _get_node_id_mapping(split_populations)
     # Intrinsic input sources retain their name unchanged
-    node_pop_name_mapping = {pop_name: pop_name for pop_name in split_populations.keys()}
+    node_pop_name_mapping = {pop_name: [pop_name] for pop_name in split_populations.keys()}
 
     # TODO: should function `_write_subcircuit_biological`,
-    # `_gather_new_external_subcircuit`, `_filter_virtual_typed_subcircuit`/`_write_subcircuit`
+    # `_gather_new_external_subcircuits`, `_filter_virtual_typed_subcircuit`/`_write_subcircuit`
     # handle node updates and config updates?
 
     new_node_files, new_edge_files = _write_subcircuit_biological(
@@ -1404,7 +1437,6 @@ def split_subcircuit(
     existing_node_pop_names = list(new_node_files.keys())
     existing_edge_pop_names = list(new_edge_files.keys())
     id_mapping_secondary = {}
-    node_pop_name_mapping_secondary = {}
     if create_external:
         # Phase A: carry over existing external_ populations from parent circuit
         write_edge_configs_a, nodes_to_write_a = _filter_virtual_typed_subcircuit(
@@ -1422,8 +1454,7 @@ def split_subcircuit(
             write_edge_configs_b,
             nodes_to_write_b,
             id_mapping_secondary,
-            node_pop_name_mapping_secondary,
-        ) = _gather_new_external_subcircuit(
+        ) = _gather_new_external_subcircuits(
             output,
             circuit,
             id_mapping,
@@ -1469,7 +1500,6 @@ def split_subcircuit(
         id_mapping,
         node_pop_name_mapping,
         id_mapping_secondary,
-        node_pop_name_mapping_secondary,
     )
 
     config = copy.deepcopy(circuit.config)

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -226,6 +226,9 @@ def _populate_edge_group(orig_group, new_group, sl, mask, overrides):
 def _finalize_edges(new_edges):
     """add datasets for `new_edges` so they fulfil SONATA spec"""
     edge_count = len(new_edges["source_node_id"])
+    for name in ("edge_type_id", "edge_group_id", "edge_group_index"):
+        if name in new_edges:
+            del new_edges[name]
     new_edges["edge_type_id"] = np.full(edge_count, -1)
     new_edges["edge_group_id"] = np.full(edge_count, 0)
     new_edges["edge_group_index"] = np.arange(edge_count, dtype=np.uint64)
@@ -276,26 +279,32 @@ def _copy_filtered_edges(
     # get groups
     orig_edges = h5in["edges"][write_edge_config.src_edge_name]
     orig_group = _get_unique_group(orig_edges)
-    new_edges = h5out.create_group("edges/" + write_edge_config.dst_edge_name)
-    new_group = new_edges.create_group(GROUP_NAME)
 
-    hdf5.create_appendable_dataset(new_edges, "source_node_id", np.uint64)
-    hdf5.create_appendable_dataset(new_edges, "target_node_id", np.uint64)
+    edge_path = "edges/" + write_edge_config.dst_edge_name
+    if edge_path in h5out:
+        # Appending to an existing edge population
+        new_edges = h5out[edge_path]
+        new_group = new_edges[GROUP_NAME]
+    else:
+        # Creating a new edge population
+        new_edges = h5out.create_group(edge_path)
+        new_group = new_edges.create_group(GROUP_NAME)
 
-    # since create_appendable_dataset already fails if we append to an existing
-    # dataset, the following attribute assignments are safe
-    new_edges["source_node_id"].attrs["node_population"] = write_edge_config.src_node_name
-    new_edges["target_node_id"].attrs["node_population"] = write_edge_config.dst_node_name
+        hdf5.create_appendable_dataset(new_edges, "source_node_id", np.uint64)
+        hdf5.create_appendable_dataset(new_edges, "target_node_id", np.uint64)
 
-    additional_attrs = {}
-    if is_neuroglial:
-        # find new name of synapse_edge_pop
-        src_syn_edge_pop = orig_edges[GROUP_NAME]["synapse_id"].attrs["edge_population"]
-        _, dst_syn_edge_pop = edge_mappings[src_syn_edge_pop]
-        # create dataset and add correct attr
-        additional_attrs["synapse_id"] = {"edge_population": dst_syn_edge_pop}
+        new_edges["source_node_id"].attrs["node_population"] = write_edge_config.src_node_name
+        new_edges["target_node_id"].attrs["node_population"] = write_edge_config.dst_node_name
 
-    _init_edge_group(orig_group, new_group, additional_attrs)
+        additional_attrs = {}
+        if is_neuroglial:
+            # find new name of synapse_edge_pop
+            src_syn_edge_pop = orig_edges[GROUP_NAME]["synapse_id"].attrs["edge_population"]
+            _, dst_syn_edge_pop = edge_mappings[src_syn_edge_pop]
+            # create dataset and add correct attr
+            additional_attrs["synapse_id"] = {"edge_population": dst_syn_edge_pop}
+
+        _init_edge_group(orig_group, new_group, additional_attrs)
 
     sgids_new = write_edge_config.src_mapping.index.to_numpy()
     tgids_new = write_edge_config.dst_mapping.index.to_numpy()
@@ -322,11 +331,11 @@ def _copy_filtered_edges(
 
     if edge_mappings is not None:
         offset = new_edges["source_node_id"].shape[0]
-        if offset != 0:
+        if offset != 0 and is_neuroglial:
             raise RuntimeError(
-                "Cannot append edges when edge_mappings is enabled and the destination already "
-                f"contains {offset} edges. The current implementation only supports edges created "
-                "in a single pass and does not capture cross-generation connections "
+                "Cannot append neuroglial edges when edge_mappings is enabled and the destination "
+                f"already contains {offset} edges. The current implementation only supports edges "
+                "created in a single pass and does not capture cross-generation connections "
                 "(old astrocyte -> new neuron or new astrocyte -> old neuron). "
                 "Only new->new connections would be handled correctly. "
                 "Appending is therefore blocked as a safety safeguard."
@@ -704,12 +713,6 @@ def _write_subcircuit_edges(
 
         # after the h5 file is closed, it's indexed if valid, or it's removed if empty
         if edge_count > 0:
-            _write_indexes(
-                edge_file_name=write_edge_config.output_path,
-                new_pop_name=write_edge_config.dst_edge_name,
-                source_node_count=sgid_count,
-                target_node_count=tgid_count,
-            )
             L.debug("Wrote %s edges to %s", edge_count, output_path)
         elif is_file_empty:
             Path(output_path).unlink(missing_ok=True)
@@ -717,7 +720,7 @@ def _write_subcircuit_edges(
         else:  # population empty, but not file
             output_path = DELETED_EMPTY_EDGES_POPULATION
 
-        return output_path
+        return output_path, edge_count, sgid_count, tgid_count
 
 
 def _get_storage_path(edge):
@@ -788,10 +791,28 @@ def _orchestrate_write_subcircuit_edges(write_edge_configs: list[WriteEdgeConfig
         write_edge_configs, key=lambda cfg: cfg.edge_type == "synapse_astrocyte"
     )
 
+    # Track the last write result per (output_path, dst_edge_name) for indexing
+    index_info = {}
     for write_edge_config in write_edge_configs_sorted:
-        new_edges_files[write_edge_config.dst_edge_name] = _write_subcircuit_edges(
+        output_path, edge_count, sgid_count, tgid_count = _write_subcircuit_edges(
             write_edge_config=write_edge_config, edge_mappings=edge_mappings
         )
+        key = (str(output_path), write_edge_config.dst_edge_name)
+        index_info[key] = (output_path, write_edge_config.dst_edge_name, edge_count, sgid_count, tgid_count)
+        new_edges_files[write_edge_config.dst_edge_name] = output_path
+
+    # Write indexes after all edges are written (handles append case)
+    for (output_path, dst_edge_name, edge_count, sgid_count, tgid_count) in index_info.values():
+        if edge_count > 0:
+            _write_indexes(
+                edge_file_name=output_path,
+                new_pop_name=dst_edge_name,
+                source_node_count=sgid_count,
+                target_node_count=tgid_count,
+            )
+        elif output_path == DELETED_EMPTY_EDGES_FILE:
+            pass  # already deleted
+        # DELETED_EMPTY_EDGES_POPULATION: nothing to do
 
     return new_edges_files
 
@@ -863,6 +884,8 @@ def _gather_new_external_subcircuit(
     )
 
     nodes_to_write = {}
+    id_mapping_secondary = {}
+    node_pop_name_mapping_secondary = {}
 
     write_edge_configs = []
     for name, edge in circuit.edges.items():
@@ -902,7 +925,8 @@ def _gather_new_external_subcircuit(
             while new_source_pop_name in existing_node_pop_names:
                 L.debug("%s already exists as an node population", new_source_pop_name)
                 new_source_pop_name = "external_" + new_source_pop_name
-            node_pop_name_mapping[new_source_pop_name] = edge.source.name
+            if new_source_pop_name not in node_pop_name_mapping:
+                node_pop_name_mapping[new_source_pop_name] = edge.source.name
 
             output_path = output / (new_name + ".h5")
             output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -918,24 +942,58 @@ def _gather_new_external_subcircuit(
                 # If mapping already exists, only add new IDs w/o changing existing!
                 # (May happen if different target populations have same external source population)
                 existing_mapping = id_mapping[new_source_pop_name]
-                is_existing = _isin(wanted_src_ids.index, existing_mapping.index)
-                wanted_src_ids.loc[is_existing] = existing_mapping.loc[
-                    wanted_src_ids.loc[is_existing].index
-                ]
-                # New node IDs begin at the lowest unused value (max + 1).
-                # Use existing_mapping max when no overlap exists (is_existing all False),
-                # otherwise use the max from the overlapping entries in wanted_src_ids.
-                if is_existing.any():
-                    max_existing_id = wanted_src_ids[NEW_IDS].loc[is_existing].max()
-                else:
-                    max_existing_id = existing_mapping[NEW_IDS].max()
-                new_ids = np.arange(np.sum(~is_existing)) + int(max_existing_id) + 1
-                wanted_src_ids.loc[~is_existing, NEW_IDS] = new_ids
 
-                # And merge new into existing
-                id_mapping[new_source_pop_name] = pd.concat(
-                    [existing_mapping, wanted_src_ids.loc[~is_existing]], axis=0
+                # Check if existing mapping came from a different source population
+                existing_parent = node_pop_name_mapping.get(new_source_pop_name)
+                different_source = (
+                    existing_parent is not None
+                    and existing_parent != edge.source.name
                 )
+
+                if different_source:
+                    # Nodes from a different parent population — store separately
+                    # to avoid index collisions. Will be merged at write time.
+                    # Deduplicate against already-added secondary nodes
+                    if new_source_pop_name in id_mapping_secondary:
+                        already_added = id_mapping_secondary[new_source_pop_name]
+                        is_existing = _isin(wanted_src_ids.index, already_added.index)
+                        wanted_src_ids.loc[is_existing] = already_added.loc[
+                            wanted_src_ids.loc[is_existing].index
+                        ]
+                        if is_existing.any():
+                            max_existing_id = already_added[NEW_IDS].max()
+                        else:
+                            max_existing_id = existing_mapping[NEW_IDS].max()
+                        n_new = int(np.sum(~is_existing))
+                        if n_new > 0:
+                            new_ids = np.arange(n_new) + int(max_existing_id) + 1
+                            wanted_src_ids.loc[~is_existing, NEW_IDS] = new_ids
+                            id_mapping_secondary[new_source_pop_name] = pd.concat(
+                                [already_added, wanted_src_ids.loc[~is_existing]], axis=0
+                            )
+                    else:
+                        max_existing_id = existing_mapping[NEW_IDS].max()
+                        new_ids = np.arange(len(wanted_src_ids)) + int(max_existing_id) + 1
+                        wanted_src_ids[NEW_IDS] = new_ids
+                        id_mapping_secondary[new_source_pop_name] = wanted_src_ids
+                    node_pop_name_mapping_secondary[new_source_pop_name] = edge.source.name
+                else:
+                    is_existing = _isin(wanted_src_ids.index, existing_mapping.index)
+                    wanted_src_ids.loc[is_existing] = existing_mapping.loc[
+                        wanted_src_ids.loc[is_existing].index
+                    ]
+                    # New node IDs begin at the lowest unused value (max + 1).
+                    if is_existing.any():
+                        max_existing_id = wanted_src_ids[NEW_IDS].loc[is_existing].max()
+                    else:
+                        max_existing_id = existing_mapping[NEW_IDS].max()
+                    new_ids = np.arange(np.sum(~is_existing)) + int(max_existing_id) + 1
+                    wanted_src_ids.loc[~is_existing, NEW_IDS] = new_ids
+
+                    # And merge new into existing
+                    id_mapping[new_source_pop_name] = pd.concat(
+                        [existing_mapping, wanted_src_ids.loc[~is_existing]], axis=0
+                    )
             else:
                 id_mapping[new_source_pop_name] = wanted_src_ids
 
@@ -952,13 +1010,23 @@ def _gather_new_external_subcircuit(
             )
             write_edge_configs.append(write_edge_config)
 
-            # Use accumulated id_mapping index for node IDs (merges across all edges)
-            nodes_to_write[new_source_pop_name] = (
-                edge.source.name,
-                id_mapping[new_source_pop_name].index.to_numpy(),
-            )
+            # Build nodes_to_write for this population.
+            # Only include nodes that _gather is responsible for (not filter's).
+            if new_source_pop_name in id_mapping_secondary:
+                # Mixed source: only write the secondary (new biophysical) nodes.
+                # The primary (carried-over external) nodes are handled by _filter.
+                nodes_to_write[new_source_pop_name] = [(
+                    node_pop_name_mapping_secondary[new_source_pop_name],
+                    id_mapping_secondary[new_source_pop_name].index.to_numpy(),
+                )]
+            else:
+                # Single source: all nodes come from _gather
+                nodes_to_write[new_source_pop_name] = [(
+                    edge.source.name,
+                    id_mapping[new_source_pop_name].index.to_numpy(),
+                )]
 
-    return write_edge_configs, nodes_to_write
+    return write_edge_configs, nodes_to_write, id_mapping_secondary, node_pop_name_mapping_secondary
 
 
 def _filter_virtual_typed_subcircuit(
@@ -1041,7 +1109,7 @@ def _filter_virtual_typed_subcircuit(
         )
         for edge_pop_name, edge in virtual_populations.items()
     ]
-    nodes_to_write = {name: (name, ids) for name, ids in pop_used_source_node_ids.items()}
+    nodes_to_write = {name: [(name, ids)] for name, ids in pop_used_source_node_ids.items()}
 
     return write_edge_configs, nodes_to_write
 
@@ -1058,9 +1126,10 @@ def _write_subcircuit(
         output: Path where files will be written.
         circuit: bluepysnap Circuit object.
         write_edge_configs: list of WriteEdgeConfig (fully constructed).
-        nodes_to_write: dict of output_pop_name -> (source_pop_name, node_ids).
-            source_pop_name is the population to read from in the circuit,
-            node_ids are the IDs to extract from that population.
+        nodes_to_write: dict of output_pop_name -> list of (source_pop_name, node_ids).
+            Each entry is a list of sources to read and concatenate for that
+            output population. source_pop_name is the population to read from
+            in the circuit, node_ids are the IDs to extract.
 
     Returns:
         (new_node_files, new_edges_files): dicts of population_name -> path.
@@ -1068,8 +1137,9 @@ def _write_subcircuit(
     new_edges_files = _orchestrate_write_subcircuit_edges(write_edge_configs=write_edge_configs)
 
     new_node_files = {}
-    for population_name, (source_pop_name, ids) in nodes_to_write.items():
-        df = circuit.nodes[source_pop_name].get(ids).reset_index(drop=True)
+    for population_name, sources in nodes_to_write.items():
+        dfs = [circuit.nodes[src_pop].get(ids) for src_pop, ids in sources]
+        df = pd.concat(dfs, ignore_index=True)
         nodes_path = Path(output) / population_name / "nodes.h5"
         nodes_path.parent.mkdir(parents=True, exist_ok=True)
         new_node_files[population_name] = _save_sonata_nodes(nodes_path, df, population_name)
@@ -1226,8 +1296,16 @@ def _set_original_ids(this_mapping: dict, parent_mapping: dict | None) -> None:
             entry[ORIG_NAME] = parent_mapping[parent_pop][ORIG_NAME]
 
 
-def _write_mapping(output, parent_circ, id_mapping, node_pop_name_mapping):
+def _write_mapping(
+    output, parent_circ, id_mapping, node_pop_name_mapping,
+    id_mapping_secondary=None, node_pop_name_mapping_secondary=None,
+):
     """write the id mappings between the old and new populations for future analysis"""
+    if id_mapping_secondary is None:
+        id_mapping_secondary = {}
+    if node_pop_name_mapping_secondary is None:
+        node_pop_name_mapping_secondary = {}
+
     this_mapping = _mapping_to_parent_dict(id_mapping, node_pop_name_mapping)
 
     provenance = parent_circ.config.get("components", {}).get("provenance", {})
@@ -1239,6 +1317,29 @@ def _write_mapping(output, parent_circ, id_mapping, node_pop_name_mapping):
         parent_mapping = utils.load_json(parent_root / mapping_path)
 
     _set_original_ids(this_mapping, parent_mapping)
+
+    # Merge secondary mappings (from different parent populations) into parent2_* fields
+    if id_mapping_secondary:
+        secondary_dict = _mapping_to_parent_dict(
+            id_mapping_secondary, node_pop_name_mapping_secondary
+        )
+        _set_original_ids(secondary_dict, parent_mapping)
+        for pop_name, sec_entry in secondary_dict.items():
+            assert pop_name in this_mapping, (
+                f"Secondary mapping for '{pop_name}' has no primary entry"
+            )
+            primary_entry = this_mapping[pop_name]
+            # Assert original_name matches
+            assert primary_entry[ORIG_NAME] == sec_entry[ORIG_NAME], (
+                f"Cannot merge external population '{pop_name}': "
+                f"original_name mismatch: {primary_entry[ORIG_NAME]} vs {sec_entry[ORIG_NAME]}"
+            )
+            # Combine new_ids (primary first, secondary appends)
+            primary_entry[NEW_IDS] = primary_entry[NEW_IDS] + sec_entry[NEW_IDS]
+            # Add parent2_* fields
+            primary_entry["parent2_id"] = sec_entry[PARENT_IDS]
+            primary_entry["parent2_name"] = sec_entry[PARENT_NAME]
+            primary_entry["original2_id"] = sec_entry[ORIG_IDS]
 
     mapping_fn = "id_mapping.json"
     utils.dump_json(output / mapping_fn, this_mapping)
@@ -1330,8 +1431,11 @@ def split_subcircuit(
 
     existing_node_pop_names = list(new_node_files.keys())
     existing_edge_pop_names = list(new_edge_files.keys())
+    id_mapping_secondary = {}
+    node_pop_name_mapping_secondary = {}
     if create_external:
-        write_edge_configs, nodes_to_write = _filter_virtual_typed_subcircuit(
+        # Phase A: carry over existing external_ populations from parent circuit
+        write_edge_configs_a, nodes_to_write_a = _filter_virtual_typed_subcircuit(
             output,
             circuit,
             edge_pop_to_paths,
@@ -1340,14 +1444,9 @@ def split_subcircuit(
             True,
             list_of_virtual_sources_to_ignore,
         )
-        new_virtual_node_files, new_virtual_edge_files = _write_subcircuit(
-            output,
-            circuit,
-            write_edge_configs,
-            nodes_to_write,
-        )
 
-        write_edge_configs, nodes_to_write = _gather_new_external_subcircuit(
+        # Phase B: create new externals from biophysical populations now outside subcircuit
+        write_edge_configs_b, nodes_to_write_b, id_mapping_secondary, node_pop_name_mapping_secondary = _gather_new_external_subcircuit(
             output,
             circuit,
             id_mapping,
@@ -1355,17 +1454,37 @@ def split_subcircuit(
             existing_node_pop_names,
             existing_edge_pop_names,
         )
+
+        # Merge: concatenate edge configs, merge nodes_to_write lists
+        # Align output paths: if gather has same dst_edge_name as filter,
+        # use filter's output_path so both write to the same file.
+        filter_paths = {cfg.dst_edge_name: cfg.output_path for cfg in write_edge_configs_a}
+        for cfg in write_edge_configs_b:
+            if cfg.dst_edge_name in filter_paths:
+                cfg.output_path = filter_paths[cfg.dst_edge_name]
+
+        merged_edge_configs = write_edge_configs_a + write_edge_configs_b
+        merged_nodes_to_write = dict(nodes_to_write_a)
+        for pop_name, sources in nodes_to_write_b.items():
+            if pop_name in merged_nodes_to_write:
+                merged_nodes_to_write[pop_name] = merged_nodes_to_write[pop_name] + sources
+            else:
+                merged_nodes_to_write[pop_name] = sources
+
         new_virtual_node_files, new_virtual_edge_files = _write_subcircuit(
             output,
             circuit,
-            write_edge_configs,
-            nodes_to_write,
+            merged_edge_configs,
+            merged_nodes_to_write,
         )
 
         new_node_files.update(new_virtual_node_files)
         new_edge_files.update(new_virtual_edge_files)
 
-    mapping_fn = _write_mapping(output, circuit, id_mapping, node_pop_name_mapping)
+    mapping_fn = _write_mapping(
+        output, circuit, id_mapping, node_pop_name_mapping,
+        id_mapping_secondary, node_pop_name_mapping_secondary,
+    )
 
     config = copy.deepcopy(circuit.config)
 

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -70,6 +70,14 @@ class WriteEdgeConfig:
             Path(self.output_path) if isinstance(self.output_path, str) else self.output_path
         )
 
+    @property
+    def source_node_count(self) -> int:
+        return int(max(np.max(m) for m in self.src_mapping)) + 1
+
+    @property
+    def target_node_count(self) -> int:
+        return int(np.max(self.dst_mapping)) + 1
+
 
 def _create_chunked_slices(length, chunk_size):
     """return `slices` each of size `chunk_size`, that cover `length`"""
@@ -240,35 +248,22 @@ def _h5_get_read_chunk_size():
 
 
 def _copy_filtered_edges(
-    h5out: h5py.File,
     write_edge_config: WriteEdgeConfig,
     edge_mappings: dict[str, tuple[pd.DataFrame, str]] = None,
-):
-    """
-    Copy and filter edge datasets from input HDF5 file(s) to an output HDF5 file.
+) -> int:
+    """Copy and filter edge datasets from input HDF5 file(s) to an output HDF5 file.
 
+    Opens the output file, writes filtered edges, finalizes, and closes.
     Supports multiple input sources (input_path/src_edge_name/src_mapping lists)
     which are processed sequentially into a single output edge population.
 
-    This function:
-        - Reads the source edge population(s) in chunks.
-        - Filters edges based on source and target node mappings.
-        - Copies source/target node IDs and all associated datasets.
-        - Initializes and populates new edge groups, preserving attributes.
-        - Raises errors if invalid IDs or unsupported groups (e.g., @library) are encountered.
-
     Args:
-        h5out (h5py.File): Output HDF5 file to store filtered edges.
-        write_edge_config (WriteEdgeConfig): Configuration specifying
-            source/target populations, edge names, mappings, and read chunk size.
-        edge_mappings (dict[str, tuple[pd.DataFrame, str]]): Optional dict
-            updated with old→new edge ID mappings. The key is the old edge file name,
-            pd.DataFrame is the id remapping and the last str is the new edge file name.
+        write_edge_config: Configuration specifying source/target populations,
+            edge names, mappings, output path, and read chunk size.
+        edge_mappings: Optional dict updated with old->new edge ID mappings.
 
-    Notes:
-        - Only the "dynamics_params" group is currently supported in edge groups.
-        - Supports appendable datasets; existing datasets will raise an error if re-created.
-        - Processing is chunked to handle large edge populations efficiently.
+    Returns:
+        The number of edges written.
     """
     h5_read_chunk_size = (
         write_edge_config.h5_read_chunk_size
@@ -277,89 +272,103 @@ def _copy_filtered_edges(
     )
     is_neuroglial = write_edge_config.edge_type == "synapse_astrocyte"
 
-    # Create output edge group (once, using first input as template)
-    with h5py.File(write_edge_config.input_path[0], "r") as h5_first:
-        first_orig_edges = h5_first["edges"][write_edge_config.src_edge_name[0]]
-        orig_group = _get_unique_group(first_orig_edges)
+    write_edge_config.output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        new_edges = h5out.create_group("edges/" + write_edge_config.dst_edge_name)
-        new_group = new_edges.create_group(GROUP_NAME)
+    with h5py.File(write_edge_config.output_path, "a") as h5out:
+        # Create output edge group (once, using first input as template)
+        with h5py.File(write_edge_config.input_path[0], "r") as h5_first:
+            first_orig_edges = h5_first["edges"][write_edge_config.src_edge_name[0]]
+            orig_group = _get_unique_group(first_orig_edges)
 
-        hdf5.create_appendable_dataset(new_edges, "source_node_id", np.uint64)
-        hdf5.create_appendable_dataset(new_edges, "target_node_id", np.uint64)
+            new_edges = h5out.create_group("edges/" + write_edge_config.dst_edge_name)
+            new_group = new_edges.create_group(GROUP_NAME)
 
-        new_edges["source_node_id"].attrs["node_population"] = write_edge_config.src_node_name
-        new_edges["target_node_id"].attrs["node_population"] = write_edge_config.dst_node_name
+            hdf5.create_appendable_dataset(new_edges, "source_node_id", np.uint64)
+            hdf5.create_appendable_dataset(new_edges, "target_node_id", np.uint64)
 
-        additional_attrs = {}
-        if is_neuroglial:
-            src_syn_edge_pop = orig_group["synapse_id"].attrs["edge_population"]
-            _, dst_syn_edge_pop = edge_mappings[src_syn_edge_pop]
-            additional_attrs["synapse_id"] = {"edge_population": dst_syn_edge_pop}
+            new_edges["source_node_id"].attrs["node_population"] = write_edge_config.src_node_name
+            new_edges["target_node_id"].attrs["node_population"] = write_edge_config.dst_node_name
 
-        _init_edge_group(orig_group, new_group, additional_attrs)
+            additional_attrs = {}
+            if is_neuroglial:
+                src_syn_edge_pop = orig_group["synapse_id"].attrs["edge_population"]
+                _, dst_syn_edge_pop = edge_mappings[src_syn_edge_pop]
+                additional_attrs["synapse_id"] = {"edge_population": dst_syn_edge_pop}
 
-    # Process each input source
-    tgids_new = write_edge_config.dst_mapping.index.to_numpy()
-    assert (tgids_new >= 0).all(), "Target population ids must be positive."
+            _init_edge_group(orig_group, new_group, additional_attrs)
 
-    for input_path, src_edge_name, src_mapping in zip(
-        write_edge_config.input_path,
-        write_edge_config.src_edge_name,
-        write_edge_config.src_mapping,
-    ):
-        sgids_new = src_mapping.index.to_numpy()
-        assert (sgids_new >= 0).all(), "Source population ids must be positive."
+        # Process each input source
+        tgids_new = write_edge_config.dst_mapping.index.to_numpy()
+        assert (tgids_new >= 0).all(), "Target population ids must be positive."
 
-        with h5py.File(input_path, "r") as h5in:
-            orig_edges = h5in["edges"][src_edge_name]
+        for input_path, src_edge_name, src_mapping in zip(
+            write_edge_config.input_path,
+            write_edge_config.src_edge_name,
+            write_edge_config.src_mapping,
+        ):
+            sgids_new = src_mapping.index.to_numpy()
+            assert (sgids_new >= 0).all(), "Source population ids must be positive."
 
-            total_chunks = math.ceil(len(orig_edges["source_node_id"]) / h5_read_chunk_size)
-            L.debug(
-                "Processing %s edges in %s chunks of size %s [src_edge_name=%s]",
-                len(orig_edges["source_node_id"]),
-                total_chunks,
-                h5_read_chunk_size,
-                src_edge_name,
-            )
+            with h5py.File(input_path, "r") as h5in:
+                orig_edges = h5in["edges"][src_edge_name]
 
-            sl_and_masks = _compute_chunks_and_masks(
-                orig_edges=orig_edges,
-                sgids_new=sgids_new,
-                tgids_new=tgids_new,
-                h5_read_chunk_size=h5_read_chunk_size,
-                edge_mappings=edge_mappings,
-                is_neuroglial=is_neuroglial,
-            )
+                total_chunks = math.ceil(len(orig_edges["source_node_id"]) / h5_read_chunk_size)
+                L.debug(
+                    "Processing %s edges in %s chunks of size %s [src_edge_name=%s]",
+                    len(orig_edges["source_node_id"]),
+                    total_chunks,
+                    h5_read_chunk_size,
+                    src_edge_name,
+                )
 
-            if edge_mappings is not None:
-                offset = new_edges["source_node_id"].shape[0]
-                if offset != 0 and is_neuroglial:
-                    raise RuntimeError(
-                        "Cannot append neuroglial edges when edge_mappings is enabled and the "
-                        f"destination already contains {offset} edges."
+                sl_and_masks = _compute_chunks_and_masks(
+                    orig_edges=orig_edges,
+                    sgids_new=sgids_new,
+                    tgids_new=tgids_new,
+                    h5_read_chunk_size=h5_read_chunk_size,
+                    edge_mappings=edge_mappings,
+                    is_neuroglial=is_neuroglial,
+                )
+
+                if edge_mappings is not None:
+                    offset = new_edges["source_node_id"].shape[0]
+                    if offset != 0 and is_neuroglial:
+                        raise RuntimeError(
+                            "Cannot append neuroglial edges when edge_mappings is enabled and the "
+                            f"destination already contains {offset} edges."
+                        )
+
+                    assert src_edge_name not in edge_mappings, (
+                        f"Source edge population '{src_edge_name}' already exists in edge_mappings."
+                    )
+                    edge_mappings[src_edge_name] = (
+                        _compute_edge_mapping(sl_and_masks=sl_and_masks, offset=offset),
+                        write_edge_config.dst_edge_name,
                     )
 
-                assert src_edge_name not in edge_mappings, (
-                    f"Source edge population '{src_edge_name}' already exists in edge_mappings."
-                )
-                edge_mappings[src_edge_name] = (
-                    _compute_edge_mapping(sl_and_masks=sl_and_masks, offset=offset),
-                    write_edge_config.dst_edge_name,
+                _write_masked_edges(
+                    sl_and_masks=sl_and_masks,
+                    new_edges=new_edges,
+                    orig_edges=orig_edges,
+                    src_mapping=src_mapping,
+                    dst_mapping=write_edge_config.dst_mapping,
+                    edge_mappings=edge_mappings,
+                    is_neuroglial=is_neuroglial,
                 )
 
-            _write_masked_edges(
-                sl_and_masks=sl_and_masks,
-                new_edges=new_edges,
-                orig_edges=orig_edges,
-                src_mapping=src_mapping,
-                dst_mapping=write_edge_config.dst_mapping,
-                edge_mappings=edge_mappings,
-                is_neuroglial=is_neuroglial,
-            )
+        edge_count = len(new_edges["source_node_id"])
 
-    L.debug("Finalize edges")
-    _finalize_edges(new_edges)
+        # Verify consistency
+        if edge_count > 0:
+            assert write_edge_config.source_node_count >= int(np.max(new_edges["source_node_id"]))
+            assert write_edge_config.target_node_count >= int(np.max(new_edges["target_node_id"]))
+            L.debug("Finalize edges")
+            _finalize_edges(new_edges)
+        else:
+            # Remove empty population from the file
+            del h5out[f"edges/{write_edge_config.dst_edge_name}"]
+
+    return edge_count
 
 
 def _compute_edge_mapping(sl_and_masks, offset=0):
@@ -443,24 +452,6 @@ def _write_masked_edges(
         _populate_edge_group(orig_edges[GROUP_NAME], new_edges[GROUP_NAME], sl, mask, overrides)
 
 
-def _get_node_counts(
-    h5out: h5py.File, new_edge_pop_name: str, src_mapping: pd.DataFrame, dst_mapping: pd.DataFrame
-):
-    """for `h5out`, return the `new_edge_pop_name`, `source_node_count`, and `target_node_count`"""
-
-    source_node_count = int(np.max(src_mapping)) + 1
-    target_node_count = int(np.max(dst_mapping)) + 1
-
-    new_edges = h5out["edges"][new_edge_pop_name]
-    edge_count = len(new_edges["source_node_id"])
-
-    if edge_count > 0:
-        assert source_node_count >= int(np.max(new_edges["source_node_id"]))
-        assert target_node_count >= int(np.max(new_edges["target_node_id"]))
-
-    return edge_count, source_node_count, target_node_count
-
-
 def _write_indexes(
     edge_file_name: str | Path, new_pop_name: str, source_node_count: int, target_node_count: int
 ):
@@ -506,15 +497,16 @@ def _write_edges(
             )
 
             L.debug("Writing to  %s", write_edge_config.output_path)
-            with h5py.File(write_edge_config.output_path, "w") as h5out:
-                _copy_filtered_edges(h5out=h5out, write_edge_config=write_edge_config)
-                edge_count, sgid_count, tgid_count = _get_node_counts(
-                    h5out, edge_pop_name, id_mapping[src_node_pop], id_mapping[dst_node_pop]
-                )
+            edge_count = _copy_filtered_edges(write_edge_config=write_edge_config)
 
-            # after the h5 file is closed, it's indexed if valid, or it's removed if empty
+            # after the file is closed, it's indexed if valid, or it's removed if empty
             if edge_count > 0:
-                _write_indexes(write_edge_config.output_path, edge_pop_name, sgid_count, tgid_count)
+                _write_indexes(
+                    write_edge_config.output_path,
+                    edge_pop_name,
+                    write_edge_config.source_node_count,
+                    write_edge_config.target_node_count,
+                )
                 L.debug("Wrote %s edges to %s", edge_count, write_edge_config.output_path)
                 written_edges += edge_count
             else:
@@ -666,11 +658,11 @@ def simple_split_subcircuit(output, node_set_name, node_set_path, nodes_path, ed
 def _write_subcircuit_edges(
     write_edge_config: WriteEdgeConfig, edge_mappings: dict[str, tuple[pd.DataFrame, str]]
 ):
-    """copy a population to an edge file
+    """Write a filtered edge population to an HDF5 file.
 
-    If DELETED_EMPTY_EDGES_FILE is returned, the file was removed since no
-    populations existed in it any more
-    If DELETED_EMPTY_EDGES_POPULATION is returned, the population was removed
+    Returns:
+        (output_path, edge_count): the path written to (or sentinel if empty),
+        and the number of edges written.
     """
     output_path = write_edge_config.output_path
 
@@ -682,39 +674,24 @@ def _write_subcircuit_edges(
         str(output_path),
     )
 
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+    edge_count = _copy_filtered_edges(
+        write_edge_config=write_edge_config,
+        edge_mappings=edge_mappings,
+    )
 
-    is_file_empty = False
-    with h5py.File(output_path, "a") as h5out:
-        _copy_filtered_edges(
-            h5out=h5out,
-            write_edge_config=write_edge_config,
-            edge_mappings=edge_mappings,
-        )
-
-        # Use combined src_mapping for node count (covers all inputs)
-        combined_src_mapping = pd.concat(write_edge_config.src_mapping)
-        edge_count, sgid_count, tgid_count = _get_node_counts(
-            h5out=h5out,
-            new_edge_pop_name=write_edge_config.dst_edge_name,
-            src_mapping=combined_src_mapping,
-            dst_mapping=write_edge_config.dst_mapping,
-        )
-
-        if edge_count == 0:
-            del h5out[f"/edges/{write_edge_config.dst_edge_name}"]
-            is_file_empty = len(h5out["/edges"]) == 0
-
-    # after the h5 file is closed, it's indexed if valid, or it's removed if empty
     if edge_count > 0:
         L.debug("Wrote %s edges to %s", edge_count, output_path)
-    elif is_file_empty:
-        Path(output_path).unlink(missing_ok=True)
-        output_path = DELETED_EMPTY_EDGES_FILE
-    else:  # population empty, but not file
-        output_path = DELETED_EMPTY_EDGES_POPULATION
+    elif output_path.exists():
+        # Check if the file has any other populations; if not, remove it
+        with h5py.File(output_path, "r") as h5:
+            is_file_empty = len(h5["edges"]) == 0
+        if is_file_empty:
+            output_path.unlink(missing_ok=True)
+            output_path = DELETED_EMPTY_EDGES_FILE
+        else:
+            output_path = DELETED_EMPTY_EDGES_POPULATION
 
-    return output_path, edge_count, sgid_count, tgid_count
+    return output_path, edge_count
 
 
 def _get_storage_path(edge):
@@ -786,7 +763,7 @@ def _orchestrate_write_subcircuit_edges(write_edge_configs: list[WriteEdgeConfig
     )
 
     for write_edge_config in write_edge_configs_sorted:
-        output_path, edge_count, sgid_count, tgid_count = _write_subcircuit_edges(
+        output_path, edge_count = _write_subcircuit_edges(
             write_edge_config=write_edge_config, edge_mappings=edge_mappings
         )
 
@@ -794,8 +771,8 @@ def _orchestrate_write_subcircuit_edges(write_edge_configs: list[WriteEdgeConfig
             _write_indexes(
                 edge_file_name=output_path,
                 new_pop_name=write_edge_config.dst_edge_name,
-                source_node_count=sgid_count,
-                target_node_count=tgid_count,
+                source_node_count=write_edge_config.source_node_count,
+                target_node_count=write_edge_config.target_node_count,
             )
 
         new_edges_files[write_edge_config.dst_edge_name] = output_path

--- a/brainbuilder/utils/sonata/visualize.py
+++ b/brainbuilder/utils/sonata/visualize.py
@@ -3,6 +3,7 @@
 
 import json
 from collections import Counter
+from enum import StrEnum
 from pathlib import Path
 
 import bluepysnap
@@ -11,6 +12,30 @@ import h5py
 # Populations with more nodes than this threshold are shown as a single
 # cluster node with population-level edges instead of individual nodes.
 _MAX_NODES_DETAILED = 10
+
+
+class PopulationType(StrEnum):
+    """Classification of a node population for visualization purposes."""
+
+    BIOPHYSICAL = "biophysical"
+    VIRTUAL = "virtual"
+    EXTERNAL = "external"
+
+    @property
+    def color(self) -> str:
+        return {
+            PopulationType.BIOPHYSICAL: "lightyellow",
+            PopulationType.VIRTUAL: "lightblue",
+            PopulationType.EXTERNAL: "lightsalmon",
+        }.get(self, "white")
+
+    @classmethod
+    def from_population(cls, pop_name: str, pop_type: str | None) -> "PopulationType":
+        if pop_name.startswith("external_"):
+            return cls.EXTERNAL
+        if pop_type == "virtual":
+            return cls.VIRTUAL
+        return cls.BIOPHYSICAL
 
 
 def _load_id_mapping(circuit_config_path):
@@ -30,16 +55,6 @@ def _load_id_mapping(circuit_config_path):
 
     mapping = json.loads(mapping_file.read_text())
     return mapping
-
-
-def _classify_population(pop_name, pop_type, id_mapping):
-    """Classify a population for coloring purposes.
-
-    External if name starts with "external_", otherwise use circuit_config type.
-    """
-    if pop_name.startswith("external_"):
-        return "external"
-    return pop_type or "biophysical"
 
 
 def draw_circuit(
@@ -83,32 +98,22 @@ def draw_circuit(
     if title:
         dot.attr(label=title, labelloc="t", fontsize="14")
 
-    pop_colors = {
-        "virtual": "lightblue",
-        "biophysical": "lightyellow",
-        "external": "lightsalmon",
-    }
     detailed_pops = set()
 
     for pop_name, pop in circuit.nodes.items():
-        pop_type = pop.type or "biophysical"
-        classification = _classify_population(pop_name, pop_type, id_mapping)
-        color = pop_colors.get(classification, "white")
+        pop_type = PopulationType.from_population(pop_name, pop.type)
 
         # Get original IDs for labels if mapping exists
         parent_ids = None
         if id_mapping and pop_name in id_mapping:
             entry = id_mapping[pop_name]
             parent_ids = entry.get("original_id", entry.get("parent_id"))
-            # Append secondary original IDs if present (merged external populations)
-            if "original2_id" in entry and parent_ids is not None:
-                parent_ids = parent_ids + entry["original2_id"]
 
         if pop.size <= max_nodes_detailed:
             detailed_pops.add(pop_name)
             with dot.subgraph(name=f"cluster_{pop_name}") as sub:
                 sub.attr(
-                    label=f"{pop_name} ({classification}, {pop.size})", style="filled", color=color
+                    label=f"{pop_name} ({pop_type}, {pop.size})", style="filled", color=pop_type.color
                 )
                 prev = None
                 for i in range(pop.size):
@@ -120,10 +125,10 @@ def draw_circuit(
         else:
             dot.node(
                 f"{pop_name}__summary",
-                label=f"{pop_name}\n({classification}, {pop.size})",
+                label=f"{pop_name}\n({pop_type}, {pop.size})",
                 shape="box",
                 style="filled",
-                fillcolor=color,
+                fillcolor=pop_type.color,
             )
 
     # Edges — group duplicates and show count
@@ -148,10 +153,6 @@ def draw_circuit(
         else:
             src_node = f"{src_name}__summary" if not src_detailed else f"{src_name}__{sgids[0]}"
             tgt_node = f"{tgt_name}__summary" if not tgt_detailed else f"{tgt_name}__{tgids[0]}"
-            if not src_detailed:
-                src_node = f"{src_name}__summary"
-            if not tgt_detailed:
-                tgt_node = f"{tgt_name}__summary"
             dot.edge(src_node, tgt_node, label=str(len(sgids)), fontsize="8")
 
     if output_path:

--- a/brainbuilder/utils/sonata/visualize.py
+++ b/brainbuilder/utils/sonata/visualize.py
@@ -95,12 +95,14 @@ def draw_circuit(
         classification = _classify_population(pop_name, pop_type, id_mapping)
         color = pop_colors.get(classification, "white")
 
-        # Get parent IDs for labels if mapping exists
+        # Get original IDs for labels if mapping exists
         parent_ids = None
         if id_mapping and pop_name in id_mapping:
-            parent_ids = id_mapping[pop_name].get(
-                "original_id", id_mapping[pop_name].get("parent_id")
-            )
+            entry = id_mapping[pop_name]
+            parent_ids = entry.get("original_id", entry.get("parent_id"))
+            # Append secondary original IDs if present (merged external populations)
+            if "original2_id" in entry and parent_ids is not None:
+                parent_ids = parent_ids + entry["original2_id"]
 
         if pop.size <= max_nodes_detailed:
             detailed_pops.add(pop_name)

--- a/brainbuilder/utils/sonata/visualize.py
+++ b/brainbuilder/utils/sonata/visualize.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Visualize a SONATA circuit as a graph with populations as clusters."""
+
+import json
+from collections import Counter
+from pathlib import Path
+
+import bluepysnap
+import h5py
+
+# Populations with more nodes than this threshold are shown as a single
+# cluster node with population-level edges instead of individual nodes.
+_MAX_NODES_DETAILED = 10
+
+
+def _load_id_mapping(circuit_config_path):
+    """Load id_mapping from circuit provenance if available.
+
+    Returns:
+        dict: pop_name -> list of parent_ids, or None if no mapping exists.
+    """
+    config = json.loads(Path(circuit_config_path).read_text())
+    mapping_path = config.get("components", {}).get("provenance", {}).get("id_mapping")
+    if not mapping_path:
+        return None
+
+    mapping_file = Path(circuit_config_path).parent / mapping_path
+    if not mapping_file.exists():
+        return None
+
+    mapping = json.loads(mapping_file.read_text())
+    return mapping
+
+
+def _classify_population(pop_name, pop_type, id_mapping):
+    """Classify a population for coloring purposes.
+
+    External if name starts with "external_", otherwise use circuit_config type.
+    """
+    if pop_name.startswith("external_"):
+        return "external"
+    return pop_type or "biophysical"
+
+
+def draw_circuit(
+    circuit_config_path, output_path=None, max_nodes_detailed=_MAX_NODES_DETAILED, title=None
+):
+    """Draw a SONATA circuit using graphviz with populations as clusters.
+
+    For small populations (<=max_nodes_detailed), individual nodes and edges
+    are shown. For large populations, a single summary node is shown with
+    population-level edges. Duplicate edges are collapsed with a count label.
+
+    If an id_mapping exists in provenance, node labels show the parent (original)
+    IDs instead of the local IDs. External populations get a distinct color.
+
+    Args:
+        circuit_config_path: Path to circuit_config.json.
+        output_path: If provided, save the rendered image to this path.
+            Otherwise, render to a temp file and open it.
+        max_nodes_detailed: Populations with more nodes than this are shown
+            as a single summary node.
+
+    Requires:
+        pip install brainbuilder[viz]
+        System graphviz: brew install graphviz (macOS) / apt install graphviz (Linux)
+    """
+    try:
+        import graphviz
+    except ImportError as e:
+        raise ImportError(
+            "graphviz Python package is required for visualization. "
+            "Install with: pip install brainbuilder[viz]\n"
+            "Also requires system graphviz: brew install graphviz"
+        ) from e
+
+    circuit = bluepysnap.Circuit(str(circuit_config_path))
+    id_mapping = _load_id_mapping(circuit_config_path)
+
+    dot = graphviz.Digraph("circuit", format="png")
+    dot.attr(rankdir="LR")
+    dot.attr("node", shape="circle", fontsize="9", width="0.3", height="0.3")
+    if title:
+        dot.attr(label=title, labelloc="t", fontsize="14")
+
+    pop_colors = {
+        "virtual": "lightblue",
+        "biophysical": "lightyellow",
+        "external": "lightsalmon",
+    }
+    detailed_pops = set()
+
+    for pop_name, pop in circuit.nodes.items():
+        pop_type = pop.type or "biophysical"
+        classification = _classify_population(pop_name, pop_type, id_mapping)
+        color = pop_colors.get(classification, "white")
+
+        # Get parent IDs for labels if mapping exists
+        parent_ids = None
+        if id_mapping and pop_name in id_mapping:
+            parent_ids = id_mapping[pop_name].get(
+                "original_id", id_mapping[pop_name].get("parent_id")
+            )
+
+        if pop.size <= max_nodes_detailed:
+            detailed_pops.add(pop_name)
+            with dot.subgraph(name=f"cluster_{pop_name}") as sub:
+                sub.attr(
+                    label=f"{pop_name} ({classification}, {pop.size})", style="filled", color=color
+                )
+                prev = None
+                for i in range(pop.size):
+                    label = str(parent_ids[i]) if parent_ids else str(i)
+                    sub.node(f"{pop_name}__{i}", label=f"<<B>{label}</B>>")
+                    if prev is not None:
+                        sub.edge(prev, f"{pop_name}__{i}", style="invis", weight="10")
+                    prev = f"{pop_name}__{i}"
+        else:
+            dot.node(
+                f"{pop_name}__summary",
+                label=f"{pop_name}\n({classification}, {pop.size})",
+                shape="box",
+                style="filled",
+                fillcolor=color,
+            )
+
+    # Edges — group duplicates and show count
+    for edge_name, edge in circuit.edges.items():
+        src_name = edge.source.name
+        tgt_name = edge.target.name
+        src_detailed = src_name in detailed_pops
+        tgt_detailed = tgt_name in detailed_pops
+
+        with h5py.File(edge.h5_filepath, "r") as h5:
+            sgids = h5[f"edges/{edge_name}/source_node_id"][:]
+            tgids = h5[f"edges/{edge_name}/target_node_id"][:]
+
+        if src_detailed and tgt_detailed:
+            edge_counts = Counter(zip(sgids.tolist(), tgids.tolist()))
+            for (s, t), count in edge_counts.items():
+                attrs = {}
+                if count > 1:
+                    attrs["label"] = str(count)
+                    attrs["fontsize"] = "8"
+                dot.edge(f"{src_name}__{s}", f"{tgt_name}__{t}", **attrs)
+        else:
+            src_node = f"{src_name}__summary" if not src_detailed else f"{src_name}__{sgids[0]}"
+            tgt_node = f"{tgt_name}__summary" if not tgt_detailed else f"{tgt_name}__{tgids[0]}"
+            if not src_detailed:
+                src_node = f"{src_name}__summary"
+            if not tgt_detailed:
+                tgt_node = f"{tgt_name}__summary"
+            dot.edge(src_node, tgt_node, label=str(len(sgids)), fontsize="8")
+
+    if output_path:
+        dot.render(outfile=output_path, cleanup=True)
+    else:
+        import tempfile
+
+        filename = title.replace(" ", "_") if title else "circuit"
+        filepath = Path(tempfile.gettempdir()) / filename
+        dot.render(filename=str(filepath), view=True, cleanup=True)

--- a/brainbuilder/utils/sonata/visualize.py
+++ b/brainbuilder/utils/sonata/visualize.py
@@ -113,7 +113,9 @@ def draw_circuit(
             detailed_pops.add(pop_name)
             with dot.subgraph(name=f"cluster_{pop_name}") as sub:
                 sub.attr(
-                    label=f"{pop_name} ({pop_type}, {pop.size})", style="filled", color=pop_type.color
+                    label=f"{pop_name} ({pop_type}, {pop.size})",
+                    style="filled",
+                    color=pop_type.color,
                 )
                 prev = None
                 for i in range(pop.size):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ include = ["brainbuilder*"]
 [project.optional-dependencies]
 all = []  # for compatibility
 reindex = []  # for compatibility
+viz = ["graphviz"]
 
 [project.urls]
 Homepage = "https://openbraininstitute/brainbuilder"

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -1036,13 +1036,13 @@ def test_subsubcircuit_virtual_operates_on_virtuals_only(tmp_path):
     }
     subset_C_B_A = {
         "subset_C_B_A": ["subset_C_B_A_popA", "subset_C_B_A_popB", "subset_C_B_A_popC"],
-        "subset_C_B_A_popA": {"population": "A", "node_id": [0, 1, 2]},
+        "subset_C_B_A_popA": {"population": "A", "node_id": [0, 1]},
         "subset_C_B_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
         "subset_C_B_A_popC": {"population": "C", "node_id": [0, 1, 3, 4, 5]},
     }
     subset_C_A = {
         "subset_C_A": ["subset_C_A_popA", "subset_C_A_popB", "subset_C_A_popC"],
-        "subset_C_A_popA": {"population": "A", "node_id": [1, 2, 5]},
+        "subset_C_A_popA": {"population": "A", "node_id": [1, 5]},
         "subset_C_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
         "subset_C_A_popC": {"population": "C", "node_id": [0, 1, 3, 4, 5]},
     }
@@ -1054,71 +1054,116 @@ def test_subsubcircuit_virtual_operates_on_virtuals_only(tmp_path):
         do_virtual=True, create_external=True
     )
 
-    # path_c_b_a = _split_custom_subcircuit(
-    #     tmp_path / "C_B_A", str(path_b_a / "circuit_config.json"),
-    #     "subset_C_B_A", subset_C_B_A,
-    #     do_virtual=True, create_external=False
-    # )
+    path_c_b_a = _split_custom_subcircuit(
+        tmp_path / "C_B_A", str(path_b_a / "circuit_config.json"),
+        "subset_C_B_A", subset_C_B_A,
+        do_virtual=True, create_external=False
+    )
 
-    # path_c_a = _split_custom_subcircuit(
-    #     tmp_path / "C_A", circuit_config,
-    #     "subset_C_A", subset_C_A,
-    #     do_virtual=True, create_external=False
-    # )
+    path_c_a = _split_custom_subcircuit(
+        tmp_path / "C_A", circuit_config,
+        "subset_C_A", subset_C_A,
+        do_virtual=True, create_external=False
+    )
 
-    # # --- Assertions for C_B_A ---
-    # circ_c_b_a = bluepysnap.Circuit(str(path_c_b_a / "circuit_config.json"))
-    # node_pop_names = set(circ_c_b_a.nodes.keys())
+    # --- Assertions for C_B_A ---
+    circ_c_b_a = bluepysnap.Circuit(str(path_c_b_a / "circuit_config.json"))
+    node_pop_names = set(circ_c_b_a.nodes.keys())
 
-    # # do_virtual should NOT have processed external_A (it's not a genuine virtual)
-    # assert "external_A" not in node_pop_names, (
-    #     "external_A should not be extracted by do_virtual"
-    # )
+    # do_virtual should NOT have processed external_A (it's not a genuine virtual)
+    assert "external_A" not in node_pop_names, (
+        "external_A should not be extracted by do_virtual"
+    )
 
-    # # Genuine virtuals should be processed correctly
-    # assert "V1" in node_pop_names, "V1 (genuine virtual) should be extracted"
-    # assert "V2" not in node_pop_names, "V2 should be dropped (its target is outside C_B_A)"
+    # Genuine virtuals should be processed correctly
+    assert "V1" in node_pop_names, "V1 (genuine virtual) should be extracted"
+    assert "V2" not in node_pop_names, "V2 should be dropped (its target is outside C_B_A)"
 
-    # # C_A and C_B_A should be equivalent
-    # _assert_circuits_equivalent(path_c_a, path_c_b_a)
+    # C_A and C_B_A should be equivalent
+    _assert_circuits_equivalent(path_c_a, path_c_b_a)
 
 
-# def test_subsubcircuit_externals_merge(tmp_path):
-#     """TODO"""
-#     subset_B_A = {
-#         "subset_B_A": ["subset_B_A_popA", "subset_B_A_popB", "subset_B_A_popC"],
-#         "subset_B_A_popA": {"population": "A", "node_id": [1, 2, 5]},
-#         "subset_B_A_popB": {"population": "B", "node_id": [0, 1, 2, 3, 4, 5]},
-#         "subset_B_A_popC": {"population": "C", "node_id": [0, 1, 2, 3, 4, 5]},
-#     }
-#     subset_C_B_A = {
-#         "subset_C_B_A": ["subset_C_B_A_popA", "subset_C_B_A_popB", "subset_C_B_A_popC"],
-#         "subset_C_B_A_popA": {"population": "A", "node_id": [0, 1]},
-#         "subset_C_B_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
-#         "subset_C_B_A_popC": {"population": "C", "node_id": [0, 1, 4, 5]},
-#     }
-#     subset_C_A = {
-#         "subset_C_A": ["subset_C_A_popA", "subset_C_A_popB", "subset_C_A_popC"],
-#         "subset_C_A_popA": {"population": "A", "node_id": [1, 2]},
-#         "subset_C_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
-#         "subset_C_A_popC": {"population": "C", "node_id": [0, 1, 4, 5]},
-#     }
+def test_subsubcircuit_externals_merge(tmp_path):
+    """TODO"""
+    subset_B_A = {
+        "subset_B_A": ["subset_B_A_popA", "subset_B_A_popB", "subset_B_A_popC"],
+        "subset_B_A_popA": {"population": "A", "node_id": [1, 2, 5]},
+        "subset_B_A_popB": {"population": "B", "node_id": [0, 1, 2, 3, 4, 5]},
+        "subset_B_A_popC": {"population": "C", "node_id": [0, 1, 2, 3, 4, 5]},
+    }
+    subset_C_B_A = {
+        "subset_C_B_A": ["subset_C_B_A_popA", "subset_C_B_A_popB", "subset_C_B_A_popC"],
+        "subset_C_B_A_popA": {"population": "A", "node_id": [0, 1]},
+        "subset_C_B_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
+        "subset_C_B_A_popC": {"population": "C", "node_id": [0, 1, 4, 5]},
+    }
+    subset_C_A = {
+        "subset_C_A": ["subset_C_A_popA", "subset_C_A_popB", "subset_C_A_popC"],
+        "subset_C_A_popA": {"population": "A", "node_id": [1, 2]},
+        "subset_C_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
+        "subset_C_A_popC": {"population": "C", "node_id": [0, 1, 4, 5]},
+    }
 
-#     circuit_config = str(SPLIT_SUBCIRCUIT_DATA_PATH / "circuit_config.json")
+    circuit_config = str(SPLIT_SUBCIRCUIT_DATA_PATH / "circuit_config.json")
 
-#     path_b_a = _split_custom_subcircuit(
-#         tmp_path / "B_A", circuit_config, "subset_B_A", subset_B_A,
-#         do_virtual=True, create_external=True
-#     )
+    path_b_a = _split_custom_subcircuit(
+        tmp_path / "B_A", circuit_config, "subset_B_A", subset_B_A,
+        do_virtual=True, create_external=True
+    )
 
-#     path_c_b_a = _split_custom_subcircuit(
-#         tmp_path / "C_B_A", str(path_b_a / "circuit_config.json"),
-#         "subset_C_B_A", subset_C_B_A,
-#         do_virtual=True, create_external=True
-#     )
+    path_c_b_a = _split_custom_subcircuit(
+        tmp_path / "C_B_A", str(path_b_a / "circuit_config.json"),
+        "subset_C_B_A", subset_C_B_A,
+        do_virtual=True, create_external=True
+    )
 
-#     path_c_a = _split_custom_subcircuit(
-#         tmp_path / "C_A", circuit_config,
-#         "subset_C_A", subset_C_A,
-#         do_virtual=True, create_external=True
-#     )
+    path_c_a = _split_custom_subcircuit(
+        tmp_path / "C_A", circuit_config,
+        "subset_C_A", subset_C_A,
+        do_virtual=True, create_external=True
+    )
+
+
+    # --- Equivalence check: C_A ≈ C_B_A (up to node reordering in externals) ---
+    circ_c_a = bluepysnap.Circuit(str(path_c_a / "circuit_config.json"))
+    circ_c_b_a = bluepysnap.Circuit(str(path_c_b_a / "circuit_config.json"))
+
+    # Same node populations
+    assert set(circ_c_a.nodes.keys()) == set(circ_c_b_a.nodes.keys()), (
+        f"Node populations differ: {set(circ_c_a.nodes.keys())} vs {set(circ_c_b_a.nodes.keys())}"
+    )
+
+    # Same edge populations
+    assert set(circ_c_a.edges.keys()) == set(circ_c_b_a.edges.keys()), (
+        f"Edge populations differ: {set(circ_c_a.edges.keys())} vs {set(circ_c_b_a.edges.keys())}"
+    )
+
+    # Same node counts per population
+    for pop_name in circ_c_a.nodes.keys():
+        assert circ_c_a.nodes[pop_name].size == circ_c_b_a.nodes[pop_name].size, (
+            f"Node count mismatch for {pop_name}: "
+            f"{circ_c_a.nodes[pop_name].size} vs {circ_c_b_a.nodes[pop_name].size}"
+        )
+
+    # Same edge counts per population
+    for edge_name in circ_c_a.edges.keys():
+        assert circ_c_a.edges[edge_name].size == circ_c_b_a.edges[edge_name].size, (
+            f"Edge count mismatch for {edge_name}: "
+            f"{circ_c_a.edges[edge_name].size} vs {circ_c_b_a.edges[edge_name].size}"
+        )
+
+    # Same original_ids (up to reordering for external populations)
+    mapping_c_a = load_json(path_c_a / "id_mapping.json")
+    mapping_c_b_a = load_json(path_c_b_a / "id_mapping.json")
+
+    for pop_name in mapping_c_a:
+        assert pop_name in mapping_c_b_a, f"Population {pop_name} missing from C_B_A mapping"
+        orig_ids_c_a = sorted(mapping_c_a[pop_name]["original_id"])
+        # For C_B_A, original_ids may be split across primary and secondary (parent2)
+        orig_ids_c_b_a = mapping_c_b_a[pop_name].get("original_id", [])
+        if "original2_id" in mapping_c_b_a[pop_name]:
+            orig_ids_c_b_a = orig_ids_c_b_a + mapping_c_b_a[pop_name]["original2_id"]
+        orig_ids_c_b_a = sorted(orig_ids_c_b_a)
+        assert orig_ids_c_a == orig_ids_c_b_a, (
+            f"original_id mismatch for {pop_name}: {orig_ids_c_a} vs {orig_ids_c_b_a}"
+        )

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -1159,11 +1159,7 @@ def test_subsubcircuit_externals_merge(tmp_path):
     for pop_name in mapping_c_a:
         assert pop_name in mapping_c_b_a, f"Population {pop_name} missing from C_B_A mapping"
         orig_ids_c_a = sorted(mapping_c_a[pop_name]["original_id"])
-        # For C_B_A, original_ids may be split across primary and secondary (parent2)
-        orig_ids_c_b_a = mapping_c_b_a[pop_name].get("original_id", [])
-        if "original2_id" in mapping_c_b_a[pop_name]:
-            orig_ids_c_b_a = orig_ids_c_b_a + mapping_c_b_a[pop_name]["original2_id"]
-        orig_ids_c_b_a = sorted(orig_ids_c_b_a)
+        orig_ids_c_b_a = sorted(mapping_c_b_a[pop_name]["original_id"])
         assert orig_ids_c_a == orig_ids_c_b_a, (
             f"original_id mismatch for {pop_name}: {orig_ids_c_a} vs {orig_ids_c_b_a}"
         )

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -921,25 +921,17 @@ def test_copy_filtered_edges_advanced(tmp_path):
         assert out_edges["0"]["synapse_id"].attrs["edge_population"] == "new_biophysical_edge_pop"
 
 
-# --- Nested extraction tests (C_A ≈ C_B_A) ---
-
-
-def _assert_external_populations_consistent(circuit_path):
-    """Assert that populations named 'external_*' have parent_name != pop_name in id_mapping."""
-    mapping = load_json(Path(circuit_path) / "id_mapping.json")
-    for pop_name, data in mapping.items():
-        if pop_name.startswith("external_"):
-            assert data["parent_name"] != pop_name, (
-                f"External population '{pop_name}' should have parent_name != pop_name, "
-                f"but got parent_name='{data['parent_name']}'"
-            )
-
-
-def _assert_circuits_equivalent(path_a, path_b):
-    """Assert two extracted circuits are equivalent using original IDs.
+def _assert_circuits_equal(path_a, path_b, strict_order=False):
+    """Assert two extracted circuits are equal using original IDs.
 
     Checks that they have the same populations with the same original nodes,
     and the same edges (translated to original IDs).
+
+    Args:
+        path_a: Path to first circuit directory.
+        path_b: Path to second circuit directory.
+        strict_order: If True, require same node and edge ordering.
+            If False (default), allow reordering.
     """
     circ_a = bluepysnap.Circuit(str(Path(path_a) / "circuit_config.json"))
     circ_b = bluepysnap.Circuit(str(Path(path_b) / "circuit_config.json"))
@@ -953,11 +945,17 @@ def _assert_circuits_equivalent(path_a, path_b):
 
     # Same original IDs per population
     for pop_name in circ_a.nodes.keys():
-        orig_a = sorted(mapping_a[pop_name]["original_id"])
-        orig_b = sorted(mapping_b[pop_name]["original_id"])
-        assert orig_a == orig_b, (
-            f"Population '{pop_name}' original_ids differ: {orig_a} vs {orig_b}"
-        )
+        orig_a = mapping_a[pop_name]["original_id"]
+        orig_b = mapping_b[pop_name]["original_id"]
+        if strict_order:
+            assert orig_a == orig_b, (
+                f"Population '{pop_name}' original_ids differ: {orig_a} vs {orig_b}"
+            )
+        else:
+            assert sorted(orig_a) == sorted(orig_b), (
+                f"Population '{pop_name}' original_ids differ: "
+                f"{sorted(orig_a)} vs {sorted(orig_b)}"
+            )
         assert mapping_a[pop_name]["original_name"] == mapping_b[pop_name]["original_name"], (
             f"Population '{pop_name}' original_name differs"
         )
@@ -987,12 +985,18 @@ def _assert_circuits_equivalent(path_a, path_b):
             sgids_b = h5[f"edges/{edge_name}/source_node_id"][:]
             tgids_b = h5[f"edges/{edge_name}/target_node_id"][:]
 
-        edges_a = sorted((orig_src_a[int(s)], orig_tgt_a[int(t)]) for s, t in zip(sgids_a, tgids_a))
-        edges_b = sorted((orig_src_b[int(s)], orig_tgt_b[int(t)]) for s, t in zip(sgids_b, tgids_b))
+        edges_a = [(orig_src_a[int(s)], orig_tgt_a[int(t)]) for s, t in zip(sgids_a, tgids_a)]
+        edges_b = [(orig_src_b[int(s)], orig_tgt_b[int(t)]) for s, t in zip(sgids_b, tgids_b)]
 
-        assert edges_a == edges_b, (
-            f"Edge population '{edge_name}' differs:\n  {edges_a}\n  vs\n  {edges_b}"
-        )
+        if strict_order:
+            assert edges_a == edges_b, (
+                f"Edge population '{edge_name}' differs:\n  {edges_a}\n  vs\n  {edges_b}"
+            )
+        else:
+            assert sorted(edges_a) == sorted(edges_b), (
+                f"Edge population '{edge_name}' differs:\n  "
+                f"{sorted(edges_a)}\n  vs\n  {sorted(edges_b)}"
+            )
 
 
 def _split_custom_subcircuit(output, circuit_config, node_set_name, node_set_def,
@@ -1079,47 +1083,91 @@ def test_subsubcircuit_virtual_operates_on_virtuals_only(tmp_path):
     assert "V2" not in node_pop_names, "V2 should be dropped (its target is outside C_B_A)"
 
     # C_A and C_B_A should be equivalent
-    _assert_circuits_equivalent(path_c_a, path_c_b_a)
+    _assert_circuits_equal(path_c_a, path_c_b_a, True)
 
 
 def test_subsubcircuit_externals_merge(tmp_path):
-    """TODO"""
+    """Nested extraction with create_external merges external populations correctly.
+
+    Verifies that extracting C from B (from A) produces the same result as
+    extracting C directly from A, up to 3 levels of nesting (D).
+    """
+    ### Nomenclature:
+    # X_Y: circuit X derived from parent Y.
+    # Nodes removed from a biophysical population either become external
+    # (if they have at least one edge targeting a kept node) or are discarded.
+    # Virtual nodes are kept only if they have at least one edge to a kept
+    # biophysical node; otherwise they are dropped.
+
+    # B_A from A: keep A:{1,2,3,5}, B:all, C:all
+    # - external_A: {0, 4}
+    # - discarded: A:{} (none)
+    # - V1 kept: {1,2}. V1 dropped: {0,3}
+    # - V2 kept: {0}
     subset_B_A = {
         "subset_B_A": ["subset_B_A_popA", "subset_B_A_popB", "subset_B_A_popC"],
         "subset_B_A_popA": {"population": "A", "node_id": [1, 2, 3, 5]},
         "subset_B_A_popB": {"population": "B", "node_id": [0, 1, 2, 3, 4, 5]},
         "subset_B_A_popC": {"population": "C", "node_id": [0, 1, 2, 3, 4, 5]},
     }
+    # C_A from A: keep A:{1,2,3}, B:{1,2,3,4,5}, C:{0,1,2,5}
+    # - external_A: {0, 5}. Discarded A: {4}
+    # - external_C: {3}. Discarded C: {4}
+    # - discarded B: {0}
+    # - V1 kept: {1}. V1 dropped: {2}
+    # - V2 kept: {0}
     subset_C_A = {
         "subset_C_A": ["subset_C_A_popA", "subset_C_A_popB", "subset_C_A_popC"],
         "subset_C_A_popA": {"population": "A", "node_id": [1, 2, 3]},
         "subset_C_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
         "subset_C_A_popC": {"population": "C", "node_id": [0, 1, 2, 5]},
     }
+    # D_A from A: keep A:{1,2}, B:{1,3,4}, C:{0,1,2,5}
+    # - external_A: {3, 5}. Discarded A: {0, 4}
+    # - external_B: {2}. Discarded B: {0, 5}
+    # - external_C: {3}. Discarded C: {4}
+    # - V1 kept: {1}. V1 dropped: {2}
+    # - V2 kept: {0}
     subset_D_A = {
         "subset_D_A": ["subset_D_A_popA", "subset_D_A_popB", "subset_D_A_popC"],
         "subset_D_A_popA": {"population": "A", "node_id": [1, 2]},
         "subset_D_A_popB": {"population": "B", "node_id": [1, 3, 4]},
         "subset_D_A_popC": {"population": "C", "node_id": [0, 1, 2, 5]},
     }
+    # C_B_A from B_A (parent has A:local{0,1,2,3}=orig{1,2,3,5}, external_A:orig{0,4}):
+    # - Remove A:local{2} (orig 3) -> merges into external_A
+    # - Remove B:{0} -> discarded
+    # - Remove C:{3,4} -> C:3 external_C, C:4 discarded
+    # Result should equal C_A
     subset_C_B_A = {
         "subset_C_B_A": ["subset_C_B_A_popA", "subset_C_B_A_popB", "subset_C_B_A_popC"],
         "subset_C_B_A_popA": {"population": "A", "node_id": [0, 1, 2]},
         "subset_C_B_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
         "subset_C_B_A_popC": {"population": "C", "node_id": [0, 1, 2, 5]},
     }
+    # D_B_A from B_A (parent has A:local{0,1,2,3}=orig{1,2,3,5}, external_A:orig{0,4}):
+    # - Remove A:local{1,2} (orig 2,3) -> A:2(orig 3) merges into external_A, A:1(orig 2) discarded
+    # - Remove B:{0,2,5} -> B:2 external_B, rest discarded
+    # - Remove C:{3,4} -> C:3 external_C, C:4 discarded
+    # Result should equal D_A
     subset_D_B_A = {
         "subset_D_B_A": ["subset_D_B_A_popA", "subset_D_B_A_popB", "subset_D_B_A_popC"],
         "subset_D_B_A_popA": {"population": "A", "node_id": [0, 1]},
         "subset_D_B_A_popB": {"population": "B", "node_id": [1, 3, 4]},
         "subset_D_B_A_popC": {"population": "C", "node_id": [0, 1, 2, 5]},
     }
+    # D_C_A from C_A (parent has A:local{0,1,2}=orig{1,2,3}, external_A:orig{0,5}):
+    # - Remove A:local{2} (orig 3) -> merges into external_A
+    # - Remove B:local{1,4} (orig 2,5) -> B:1(orig 2) external_B, B:4(orig 5) discarded
+    # Result should equal D_A
     subset_D_C_A = {
         "subset_D_C_A": ["subset_D_C_A_popA", "subset_D_C_A_popB", "subset_D_C_A_popC"],
         "subset_D_C_A_popA": {"population": "A", "node_id": [0, 1]},
         "subset_D_C_A_popB": {"population": "B", "node_id": [0, 2, 3]},
         "subset_D_C_A_popC": {"population": "C", "node_id": [0, 1, 2, 3]},
     }
+    # D_C_B_A from C_B_A (same original content as C_A):
+    # - Same removals as D_C_A. Result should equal D_A
     subset_D_C_B_A = {
         "subset_D_C_B_A": ["subset_D_C_B_A_popA", "subset_D_C_B_A_popB", "subset_D_C_B_A_popC"],
         "subset_D_C_B_A_popA": {"population": "A", "node_id": [0, 1]},
@@ -1174,46 +1222,10 @@ def test_subsubcircuit_externals_merge(tmp_path):
     )
 
 
-    # --- Equivalence check helper ---
-    def _assert_equivalent(path_ref, path_test, label):
-        circ_ref = bluepysnap.Circuit(str(path_ref / "circuit_config.json"))
-        circ_test = bluepysnap.Circuit(str(path_test / "circuit_config.json"))
+    # All C circuits should be equal
+    _assert_circuits_equal(path_c_a, path_c_b_a)
 
-        assert set(circ_ref.nodes.keys()) == set(circ_test.nodes.keys()), (
-            f"[{label}] Node populations differ: "
-            f"{set(circ_ref.nodes.keys())} vs {set(circ_test.nodes.keys())}"
-        )
-        assert set(circ_ref.edges.keys()) == set(circ_test.edges.keys()), (
-            f"[{label}] Edge populations differ: "
-            f"{set(circ_ref.edges.keys())} vs {set(circ_test.edges.keys())}"
-        )
-        for pop_name in circ_ref.nodes.keys():
-            assert circ_ref.nodes[pop_name].size == circ_test.nodes[pop_name].size, (
-                f"[{label}] Node count mismatch for {pop_name}: "
-                f"{circ_ref.nodes[pop_name].size} vs {circ_test.nodes[pop_name].size}"
-            )
-        for edge_name in circ_ref.edges.keys():
-            assert circ_ref.edges[edge_name].size == circ_test.edges[edge_name].size, (
-                f"[{label}] Edge count mismatch for {edge_name}: "
-                f"{circ_ref.edges[edge_name].size} vs {circ_test.edges[edge_name].size}"
-            )
-        mapping_ref = load_json(path_ref / "id_mapping.json")
-        mapping_test = load_json(path_test / "id_mapping.json")
-        for pop_name in mapping_ref:
-            assert pop_name in mapping_test, (
-                f"[{label}] Population {pop_name} missing from test mapping"
-            )
-            orig_ids_ref = sorted(mapping_ref[pop_name]["original_id"])
-            orig_ids_test = sorted(mapping_test[pop_name]["original_id"])
-            assert orig_ids_ref == orig_ids_test, (
-                f"[{label}] original_id mismatch for {pop_name}: "
-                f"{orig_ids_ref} vs {orig_ids_test}"
-            )
-
-    # All C circuits should be equivalent
-    _assert_equivalent(path_c_a, path_c_b_a, "C_A vs C_B_A")
-
-    # All D circuits should be equivalent
-    _assert_equivalent(path_d_a, path_d_b_a, "D_A vs D_B_A")
-    _assert_equivalent(path_d_a, path_d_c_a, "D_A vs D_C_A")
-    _assert_equivalent(path_d_a, path_d_c_b_a, "D_A vs D_C_B_A")
+    # All D circuits should be equal
+    _assert_circuits_equal(path_d_a, path_d_b_a)
+    _assert_circuits_equal(path_d_a, path_d_c_a)
+    _assert_circuits_equal(path_d_a, path_d_c_b_a)

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -1054,71 +1054,71 @@ def test_subsubcircuit_virtual_operates_on_virtuals_only(tmp_path):
         do_virtual=True, create_external=True
     )
 
-    path_c_b_a = _split_custom_subcircuit(
-        tmp_path / "C_B_A", str(path_b_a / "circuit_config.json"),
-        "subset_C_B_A", subset_C_B_A,
-        do_virtual=True, create_external=False
-    )
+    # path_c_b_a = _split_custom_subcircuit(
+    #     tmp_path / "C_B_A", str(path_b_a / "circuit_config.json"),
+    #     "subset_C_B_A", subset_C_B_A,
+    #     do_virtual=True, create_external=False
+    # )
 
-    path_c_a = _split_custom_subcircuit(
-        tmp_path / "C_A", circuit_config,
-        "subset_C_A", subset_C_A,
-        do_virtual=True, create_external=False
-    )
+    # path_c_a = _split_custom_subcircuit(
+    #     tmp_path / "C_A", circuit_config,
+    #     "subset_C_A", subset_C_A,
+    #     do_virtual=True, create_external=False
+    # )
 
-    # --- Assertions for C_B_A ---
-    circ_c_b_a = bluepysnap.Circuit(str(path_c_b_a / "circuit_config.json"))
-    node_pop_names = set(circ_c_b_a.nodes.keys())
+    # # --- Assertions for C_B_A ---
+    # circ_c_b_a = bluepysnap.Circuit(str(path_c_b_a / "circuit_config.json"))
+    # node_pop_names = set(circ_c_b_a.nodes.keys())
 
-    # do_virtual should NOT have processed external_A (it's not a genuine virtual)
-    assert "external_A" not in node_pop_names, (
-        "external_A should not be extracted by do_virtual"
-    )
+    # # do_virtual should NOT have processed external_A (it's not a genuine virtual)
+    # assert "external_A" not in node_pop_names, (
+    #     "external_A should not be extracted by do_virtual"
+    # )
 
-    # Genuine virtuals should be processed correctly
-    assert "V1" in node_pop_names, "V1 (genuine virtual) should be extracted"
-    assert "V2" not in node_pop_names, "V2 should be dropped (its target is outside C_B_A)"
+    # # Genuine virtuals should be processed correctly
+    # assert "V1" in node_pop_names, "V1 (genuine virtual) should be extracted"
+    # assert "V2" not in node_pop_names, "V2 should be dropped (its target is outside C_B_A)"
 
-    # C_A and C_B_A should be equivalent
-    _assert_circuits_equivalent(path_c_a, path_c_b_a)
+    # # C_A and C_B_A should be equivalent
+    # _assert_circuits_equivalent(path_c_a, path_c_b_a)
 
 
-def test_subsubcircuit_externals_merge(tmp_path):
-    """TODO"""
-    subset_B_A = {
-        "subset_B_A": ["subset_B_A_popA", "subset_B_A_popB", "subset_B_A_popC"],
-        "subset_B_A_popA": {"population": "A", "node_id": [1, 2, 5]},
-        "subset_B_A_popB": {"population": "B", "node_id": [0, 1, 2, 3, 4, 5]},
-        "subset_B_A_popC": {"population": "C", "node_id": [0, 1, 2, 3, 4, 5]},
-    }
-    subset_C_B_A = {
-        "subset_C_B_A": ["subset_C_B_A_popA", "subset_C_B_A_popB", "subset_C_B_A_popC"],
-        "subset_C_B_A_popA": {"population": "A", "node_id": [0, 1]},
-        "subset_C_B_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
-        "subset_C_B_A_popC": {"population": "C", "node_id": [0, 1, 4, 5]},
-    }
-    subset_C_A = {
-        "subset_C_A": ["subset_C_A_popA", "subset_C_A_popB", "subset_C_A_popC"],
-        "subset_C_A_popA": {"population": "A", "node_id": [1, 2]},
-        "subset_C_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
-        "subset_C_A_popC": {"population": "C", "node_id": [0, 1, 4, 5]},
-    }
+# def test_subsubcircuit_externals_merge(tmp_path):
+#     """TODO"""
+#     subset_B_A = {
+#         "subset_B_A": ["subset_B_A_popA", "subset_B_A_popB", "subset_B_A_popC"],
+#         "subset_B_A_popA": {"population": "A", "node_id": [1, 2, 5]},
+#         "subset_B_A_popB": {"population": "B", "node_id": [0, 1, 2, 3, 4, 5]},
+#         "subset_B_A_popC": {"population": "C", "node_id": [0, 1, 2, 3, 4, 5]},
+#     }
+#     subset_C_B_A = {
+#         "subset_C_B_A": ["subset_C_B_A_popA", "subset_C_B_A_popB", "subset_C_B_A_popC"],
+#         "subset_C_B_A_popA": {"population": "A", "node_id": [0, 1]},
+#         "subset_C_B_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
+#         "subset_C_B_A_popC": {"population": "C", "node_id": [0, 1, 4, 5]},
+#     }
+#     subset_C_A = {
+#         "subset_C_A": ["subset_C_A_popA", "subset_C_A_popB", "subset_C_A_popC"],
+#         "subset_C_A_popA": {"population": "A", "node_id": [1, 2]},
+#         "subset_C_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
+#         "subset_C_A_popC": {"population": "C", "node_id": [0, 1, 4, 5]},
+#     }
 
-    circuit_config = str(SPLIT_SUBCIRCUIT_DATA_PATH / "circuit_config.json")
+#     circuit_config = str(SPLIT_SUBCIRCUIT_DATA_PATH / "circuit_config.json")
 
-    path_b_a = _split_custom_subcircuit(
-        tmp_path / "B_A", circuit_config, "subset_B_A", subset_B_A,
-        do_virtual=True, create_external=True
-    )
+#     path_b_a = _split_custom_subcircuit(
+#         tmp_path / "B_A", circuit_config, "subset_B_A", subset_B_A,
+#         do_virtual=True, create_external=True
+#     )
 
-    path_c_b_a = _split_custom_subcircuit(
-        tmp_path / "C_B_A", str(path_b_a / "circuit_config.json"),
-        "subset_C_B_A", subset_C_B_A,
-        do_virtual=True, create_external=True
-    )
+#     path_c_b_a = _split_custom_subcircuit(
+#         tmp_path / "C_B_A", str(path_b_a / "circuit_config.json"),
+#         "subset_C_B_A", subset_C_B_A,
+#         do_virtual=True, create_external=True
+#     )
 
-    path_c_a = _split_custom_subcircuit(
-        tmp_path / "C_A", circuit_config,
-        "subset_C_A", subset_C_A,
-        do_virtual=True, create_external=True
-    )
+#     path_c_a = _split_custom_subcircuit(
+#         tmp_path / "C_A", circuit_config,
+#         "subset_C_A", subset_C_A,
+#         do_virtual=True, create_external=True
+#     )

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -1030,7 +1030,7 @@ def test_subsubcircuit_virtual_operates_on_virtuals_only(tmp_path):
     """
     subset_B_A = {
         "subset_B_A": ["subset_B_A_popA", "subset_B_A_popB", "subset_B_A_popC"],
-        "subset_B_A_popA": {"population": "A", "node_id": [1, 2, 5]},
+        "subset_B_A_popA": {"population": "A", "node_id": [1, 5]},
         "subset_B_A_popB": {"population": "B", "node_id": [0, 1, 2, 3, 4, 5]},
         "subset_B_A_popC": {"population": "C", "node_id": [0, 1, 2, 3, 4, 5]},
     }

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -883,9 +883,8 @@ def test_copy_filtered_edges_advanced(tmp_path):
         h5_read_chunk_size=3,  # FORCE chunking
         edge_type="synapse_astrocyte"
     )
-    with h5py.File(write_edge_config.input_path, "r") as h5in, h5py.File(write_edge_config.output_path, "w") as h5out:
+    with h5py.File(write_edge_config.output_path, "w") as h5out:
         split_population._copy_filtered_edges(
-            h5in=h5in,
             h5out=h5out,
             write_edge_config=write_edge_config,
             edge_mappings=edge_mappings

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -1087,22 +1087,49 @@ def test_subsubcircuit_externals_merge(tmp_path):
     """TODO"""
     subset_B_A = {
         "subset_B_A": ["subset_B_A_popA", "subset_B_A_popB", "subset_B_A_popC"],
-        "subset_B_A_popA": {"population": "A", "node_id": [1, 2, 5]},
+        "subset_B_A_popA": {"population": "A", "node_id": [1, 2, 3, 5]},
         "subset_B_A_popB": {"population": "B", "node_id": [0, 1, 2, 3, 4, 5]},
         "subset_B_A_popC": {"population": "C", "node_id": [0, 1, 2, 3, 4, 5]},
     }
-    subset_C_B_A = {
-        "subset_C_B_A": ["subset_C_B_A_popA", "subset_C_B_A_popB", "subset_C_B_A_popC"],
-        "subset_C_B_A_popA": {"population": "A", "node_id": [0, 1]},
-        "subset_C_B_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
-        "subset_C_B_A_popC": {"population": "C", "node_id": [0, 1, 4, 5]},
-    }
     subset_C_A = {
         "subset_C_A": ["subset_C_A_popA", "subset_C_A_popB", "subset_C_A_popC"],
-        "subset_C_A_popA": {"population": "A", "node_id": [1, 2]},
+        "subset_C_A_popA": {"population": "A", "node_id": [1, 2, 3]},
         "subset_C_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
-        "subset_C_A_popC": {"population": "C", "node_id": [0, 1, 4, 5]},
+        "subset_C_A_popC": {"population": "C", "node_id": [0, 1, 2, 5]},
     }
+    subset_D_A = {
+        "subset_D_A": ["subset_D_A_popA", "subset_D_A_popB", "subset_D_A_popC"],
+        "subset_D_A_popA": {"population": "A", "node_id": [1, 2]},
+        "subset_D_A_popB": {"population": "B", "node_id": [1, 3, 4]},
+        "subset_D_A_popC": {"population": "C", "node_id": [0, 1, 2, 5]},
+    }
+    subset_C_B_A = {
+        "subset_C_B_A": ["subset_C_B_A_popA", "subset_C_B_A_popB", "subset_C_B_A_popC"],
+        "subset_C_B_A_popA": {"population": "A", "node_id": [0, 1, 2]},
+        "subset_C_B_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
+        "subset_C_B_A_popC": {"population": "C", "node_id": [0, 1, 2, 5]},
+    }
+    subset_D_B_A = {
+        "subset_D_B_A": ["subset_D_B_A_popA", "subset_D_B_A_popB", "subset_D_B_A_popC"],
+        "subset_D_B_A_popA": {"population": "A", "node_id": [0, 1]},
+        "subset_D_B_A_popB": {"population": "B", "node_id": [1, 3, 4]},
+        "subset_D_B_A_popC": {"population": "C", "node_id": [0, 1, 2, 5]},
+    }
+    subset_D_C_A = {
+        "subset_D_C_A": ["subset_D_C_A_popA", "subset_D_C_A_popB", "subset_D_C_A_popC"],
+        "subset_D_C_A_popA": {"population": "A", "node_id": [0, 1]},
+        "subset_D_C_A_popB": {"population": "B", "node_id": [0, 2, 3]},
+        "subset_D_C_A_popC": {"population": "C", "node_id": [0, 1, 2, 3]},
+    }
+    subset_D_C_B_A = {
+        "subset_D_C_B_A": ["subset_D_C_B_A_popA", "subset_D_C_B_A_popB", "subset_D_C_B_A_popC"],
+        "subset_D_C_B_A_popA": {"population": "A", "node_id": [0, 1]},
+        "subset_D_C_B_A_popB": {"population": "B", "node_id": [0, 2, 3]},
+        "subset_D_C_B_A_popC": {"population": "C", "node_id": [0, 1, 2, 3]},
+    }
+
+
+
 
     circuit_config = str(SPLIT_SUBCIRCUIT_DATA_PATH / "circuit_config.json")
 
@@ -1123,43 +1150,71 @@ def test_subsubcircuit_externals_merge(tmp_path):
         do_virtual=True, create_external=True
     )
 
-
-    # --- Equivalence check: C_A ≈ C_B_A (up to node reordering in externals) ---
-    circ_c_a = bluepysnap.Circuit(str(path_c_a / "circuit_config.json"))
-    circ_c_b_a = bluepysnap.Circuit(str(path_c_b_a / "circuit_config.json"))
-
-    # Same node populations
-    assert set(circ_c_a.nodes.keys()) == set(circ_c_b_a.nodes.keys()), (
-        f"Node populations differ: {set(circ_c_a.nodes.keys())} vs {set(circ_c_b_a.nodes.keys())}"
+    path_d_a = _split_custom_subcircuit(
+        tmp_path / "D_A", circuit_config,
+        "subset_D_A", subset_D_A,
+        do_virtual=True, create_external=True
     )
 
-    # Same edge populations
-    assert set(circ_c_a.edges.keys()) == set(circ_c_b_a.edges.keys()), (
-        f"Edge populations differ: {set(circ_c_a.edges.keys())} vs {set(circ_c_b_a.edges.keys())}"
+    path_d_b_a = _split_custom_subcircuit(
+        tmp_path / "D_B_A", str(path_b_a / "circuit_config.json"),
+        "subset_D_B_A", subset_D_B_A,
+        do_virtual=True, create_external=True
     )
 
-    # Same node counts per population
-    for pop_name in circ_c_a.nodes.keys():
-        assert circ_c_a.nodes[pop_name].size == circ_c_b_a.nodes[pop_name].size, (
-            f"Node count mismatch for {pop_name}: "
-            f"{circ_c_a.nodes[pop_name].size} vs {circ_c_b_a.nodes[pop_name].size}"
-        )
+    path_d_c_a = _split_custom_subcircuit(
+        tmp_path / "D_C_A", str(path_c_a / "circuit_config.json"),
+        "subset_D_C_A", subset_D_C_A,
+        do_virtual=True, create_external=True
+    )
 
-    # Same edge counts per population
-    for edge_name in circ_c_a.edges.keys():
-        assert circ_c_a.edges[edge_name].size == circ_c_b_a.edges[edge_name].size, (
-            f"Edge count mismatch for {edge_name}: "
-            f"{circ_c_a.edges[edge_name].size} vs {circ_c_b_a.edges[edge_name].size}"
-        )
+    path_d_c_b_a = _split_custom_subcircuit(
+        tmp_path / "D_C_B_A", str(path_c_b_a / "circuit_config.json"),
+        "subset_D_C_B_A", subset_D_C_B_A,
+        do_virtual=True, create_external=True
+    )
 
-    # Same original_ids (up to reordering for external populations)
-    mapping_c_a = load_json(path_c_a / "id_mapping.json")
-    mapping_c_b_a = load_json(path_c_b_a / "id_mapping.json")
 
-    for pop_name in mapping_c_a:
-        assert pop_name in mapping_c_b_a, f"Population {pop_name} missing from C_B_A mapping"
-        orig_ids_c_a = sorted(mapping_c_a[pop_name]["original_id"])
-        orig_ids_c_b_a = sorted(mapping_c_b_a[pop_name]["original_id"])
-        assert orig_ids_c_a == orig_ids_c_b_a, (
-            f"original_id mismatch for {pop_name}: {orig_ids_c_a} vs {orig_ids_c_b_a}"
+    # --- Equivalence check helper ---
+    def _assert_equivalent(path_ref, path_test, label):
+        circ_ref = bluepysnap.Circuit(str(path_ref / "circuit_config.json"))
+        circ_test = bluepysnap.Circuit(str(path_test / "circuit_config.json"))
+
+        assert set(circ_ref.nodes.keys()) == set(circ_test.nodes.keys()), (
+            f"[{label}] Node populations differ: "
+            f"{set(circ_ref.nodes.keys())} vs {set(circ_test.nodes.keys())}"
         )
+        assert set(circ_ref.edges.keys()) == set(circ_test.edges.keys()), (
+            f"[{label}] Edge populations differ: "
+            f"{set(circ_ref.edges.keys())} vs {set(circ_test.edges.keys())}"
+        )
+        for pop_name in circ_ref.nodes.keys():
+            assert circ_ref.nodes[pop_name].size == circ_test.nodes[pop_name].size, (
+                f"[{label}] Node count mismatch for {pop_name}: "
+                f"{circ_ref.nodes[pop_name].size} vs {circ_test.nodes[pop_name].size}"
+            )
+        for edge_name in circ_ref.edges.keys():
+            assert circ_ref.edges[edge_name].size == circ_test.edges[edge_name].size, (
+                f"[{label}] Edge count mismatch for {edge_name}: "
+                f"{circ_ref.edges[edge_name].size} vs {circ_test.edges[edge_name].size}"
+            )
+        mapping_ref = load_json(path_ref / "id_mapping.json")
+        mapping_test = load_json(path_test / "id_mapping.json")
+        for pop_name in mapping_ref:
+            assert pop_name in mapping_test, (
+                f"[{label}] Population {pop_name} missing from test mapping"
+            )
+            orig_ids_ref = sorted(mapping_ref[pop_name]["original_id"])
+            orig_ids_test = sorted(mapping_test[pop_name]["original_id"])
+            assert orig_ids_ref == orig_ids_test, (
+                f"[{label}] original_id mismatch for {pop_name}: "
+                f"{orig_ids_ref} vs {orig_ids_test}"
+            )
+
+    # All C circuits should be equivalent
+    _assert_equivalent(path_c_a, path_c_b_a, "C_A vs C_B_A")
+
+    # All D circuits should be equivalent
+    _assert_equivalent(path_d_a, path_d_b_a, "D_A vs D_B_A")
+    _assert_equivalent(path_d_a, path_d_c_a, "D_A vs D_C_A")
+    _assert_equivalent(path_d_a, path_d_c_b_a, "D_A vs D_C_B_A")

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+import shutil
 from pathlib import Path
 
 import bluepysnap
@@ -9,7 +10,7 @@ import pytest
 import utils
 from numpy.testing import assert_array_equal
 
-from brainbuilder.utils import load_json
+from brainbuilder.utils import load_json, dump_json
 from brainbuilder.utils.sonata import split_population
 from brainbuilder.utils.sonata import utils as sonata_utils
 
@@ -919,3 +920,205 @@ def test_copy_filtered_edges_advanced(tmp_path):
         expected_syn_ids = [1, 2]
         np.testing.assert_array_equal(syn_ids, expected_syn_ids)
         assert out_edges["0"]["synapse_id"].attrs["edge_population"] == "new_biophysical_edge_pop"
+
+
+# --- Nested extraction tests (C_A ≈ C_B_A) ---
+
+
+def _assert_external_populations_consistent(circuit_path):
+    """Assert that populations named 'external_*' have parent_name != pop_name in id_mapping."""
+    mapping = load_json(Path(circuit_path) / "id_mapping.json")
+    for pop_name, data in mapping.items():
+        if pop_name.startswith("external_"):
+            assert data["parent_name"] != pop_name, (
+                f"External population '{pop_name}' should have parent_name != pop_name, "
+                f"but got parent_name='{data['parent_name']}'"
+            )
+
+
+def _assert_circuits_equivalent(path_a, path_b):
+    """Assert two extracted circuits are equivalent using original IDs.
+
+    Checks that they have the same populations with the same original nodes,
+    and the same edges (translated to original IDs).
+    """
+    circ_a = bluepysnap.Circuit(str(Path(path_a) / "circuit_config.json"))
+    circ_b = bluepysnap.Circuit(str(Path(path_b) / "circuit_config.json"))
+    mapping_a = load_json(Path(path_a) / "id_mapping.json")
+    mapping_b = load_json(Path(path_b) / "id_mapping.json")
+
+    # Same node populations
+    assert set(circ_a.nodes.keys()) == set(circ_b.nodes.keys()), (
+        f"Node populations differ: {set(circ_a.nodes.keys())} vs {set(circ_b.nodes.keys())}"
+    )
+
+    # Same original IDs per population
+    for pop_name in circ_a.nodes.keys():
+        orig_a = sorted(mapping_a[pop_name]["original_id"])
+        orig_b = sorted(mapping_b[pop_name]["original_id"])
+        assert orig_a == orig_b, (
+            f"Population '{pop_name}' original_ids differ: {orig_a} vs {orig_b}"
+        )
+        assert mapping_a[pop_name]["original_name"] == mapping_b[pop_name]["original_name"], (
+            f"Population '{pop_name}' original_name differs"
+        )
+
+    # Same edge populations
+    assert set(circ_a.edges.keys()) == set(circ_b.edges.keys()), (
+        f"Edge populations differ: {set(circ_a.edges.keys())} vs {set(circ_b.edges.keys())}"
+    )
+
+    # Same edges (translated to original IDs)
+    for edge_name in circ_a.edges.keys():
+        edge_a = circ_a.edges[edge_name]
+        edge_b = circ_b.edges[edge_name]
+        src_pop = edge_a.source.name
+        tgt_pop = edge_a.target.name
+
+        # Build new_id -> original_id lookup for each circuit
+        orig_src_a = dict(zip(mapping_a[src_pop]["new_id"], mapping_a[src_pop]["original_id"]))
+        orig_tgt_a = dict(zip(mapping_a[tgt_pop]["new_id"], mapping_a[tgt_pop]["original_id"]))
+        orig_src_b = dict(zip(mapping_b[src_pop]["new_id"], mapping_b[src_pop]["original_id"]))
+        orig_tgt_b = dict(zip(mapping_b[tgt_pop]["new_id"], mapping_b[tgt_pop]["original_id"]))
+
+        with h5py.File(edge_a.h5_filepath, "r") as h5:
+            sgids_a = h5[f"edges/{edge_name}/source_node_id"][:]
+            tgids_a = h5[f"edges/{edge_name}/target_node_id"][:]
+        with h5py.File(edge_b.h5_filepath, "r") as h5:
+            sgids_b = h5[f"edges/{edge_name}/source_node_id"][:]
+            tgids_b = h5[f"edges/{edge_name}/target_node_id"][:]
+
+        edges_a = sorted((orig_src_a[int(s)], orig_tgt_a[int(t)]) for s, t in zip(sgids_a, tgids_a))
+        edges_b = sorted((orig_src_b[int(s)], orig_tgt_b[int(t)]) for s, t in zip(sgids_b, tgids_b))
+
+        assert edges_a == edges_b, (
+            f"Edge population '{edge_name}' differs:\n  {edges_a}\n  vs\n  {edges_b}"
+        )
+
+
+def _split_custom_subcircuit(output, circuit_config, node_set_name, node_set_def,
+                            do_virtual=False, create_external=False):
+    """Run split_subcircuit after injecting a custom node_set into a copy of the circuit.
+
+    Copies the circuit directory to a sibling of `output`, injects `node_set_def`
+    into the node_sets.json, and runs the extraction.
+
+    Returns:
+        Path to the output directory (same as `output`).
+    """
+    fixture = output.parent / (output.name + "_fixture")
+    shutil.copytree(Path(circuit_config).parent, fixture)
+
+    node_sets = load_json(fixture / "node_sets.json")
+    node_sets.update(node_set_def)
+    dump_json(fixture / "node_sets.json", node_sets)
+
+    split_population.split_subcircuit(
+        output, node_set_name, str(fixture / "circuit_config.json"),
+        do_virtual=do_virtual, create_external=create_external
+    )
+    return output
+
+
+def test_subsubcircuit_virtual_operates_on_virtuals_only(tmp_path):
+    """Test that do_virtual skips external populations in nested extraction.
+
+    Extracts B_A from A with do_virtual=True, create_external=True (so B_A has external_A).
+    Then extracts C_B_A from B_A with do_virtual=True, create_external=False.
+    Verifies that do_virtual does NOT process external_A (only genuine virtuals like V1).
+    Compares C_B_A against C_A (direct extraction from A) for equivalence.
+    """
+    subset_B_A = {
+        "subset_B_A": ["subset_B_A_popA", "subset_B_A_popB", "subset_B_A_popC"],
+        "subset_B_A_popA": {"population": "A", "node_id": [1, 2, 5]},
+        "subset_B_A_popB": {"population": "B", "node_id": [0, 1, 2, 3, 4, 5]},
+        "subset_B_A_popC": {"population": "C", "node_id": [0, 1, 2, 3, 4, 5]},
+    }
+    subset_C_B_A = {
+        "subset_C_B_A": ["subset_C_B_A_popA", "subset_C_B_A_popB", "subset_C_B_A_popC"],
+        "subset_C_B_A_popA": {"population": "A", "node_id": [0, 1, 2]},
+        "subset_C_B_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
+        "subset_C_B_A_popC": {"population": "C", "node_id": [0, 1, 3, 4, 5]},
+    }
+    subset_C_A = {
+        "subset_C_A": ["subset_C_A_popA", "subset_C_A_popB", "subset_C_A_popC"],
+        "subset_C_A_popA": {"population": "A", "node_id": [1, 2, 5]},
+        "subset_C_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
+        "subset_C_A_popC": {"population": "C", "node_id": [0, 1, 3, 4, 5]},
+    }
+
+    circuit_config = str(SPLIT_SUBCIRCUIT_DATA_PATH / "circuit_config.json")
+
+    path_b_a = _split_custom_subcircuit(
+        tmp_path / "B_A", circuit_config, "subset_B_A", subset_B_A,
+        do_virtual=True, create_external=True
+    )
+
+    path_c_b_a = _split_custom_subcircuit(
+        tmp_path / "C_B_A", str(path_b_a / "circuit_config.json"),
+        "subset_C_B_A", subset_C_B_A,
+        do_virtual=True, create_external=False
+    )
+
+    path_c_a = _split_custom_subcircuit(
+        tmp_path / "C_A", circuit_config,
+        "subset_C_A", subset_C_A,
+        do_virtual=True, create_external=False
+    )
+
+    # --- Assertions for C_B_A ---
+    circ_c_b_a = bluepysnap.Circuit(str(path_c_b_a / "circuit_config.json"))
+    node_pop_names = set(circ_c_b_a.nodes.keys())
+
+    # do_virtual should NOT have processed external_A (it's not a genuine virtual)
+    assert "external_A" not in node_pop_names, (
+        "external_A should not be extracted by do_virtual"
+    )
+
+    # Genuine virtuals should be processed correctly
+    assert "V1" in node_pop_names, "V1 (genuine virtual) should be extracted"
+    assert "V2" not in node_pop_names, "V2 should be dropped (its target is outside C_B_A)"
+
+    # C_A and C_B_A should be equivalent
+    _assert_circuits_equivalent(path_c_a, path_c_b_a)
+
+
+def test_subsubcircuit_externals_merge(tmp_path):
+    """TODO"""
+    subset_B_A = {
+        "subset_B_A": ["subset_B_A_popA", "subset_B_A_popB", "subset_B_A_popC"],
+        "subset_B_A_popA": {"population": "A", "node_id": [1, 2, 5]},
+        "subset_B_A_popB": {"population": "B", "node_id": [0, 1, 2, 3, 4, 5]},
+        "subset_B_A_popC": {"population": "C", "node_id": [0, 1, 2, 3, 4, 5]},
+    }
+    subset_C_B_A = {
+        "subset_C_B_A": ["subset_C_B_A_popA", "subset_C_B_A_popB", "subset_C_B_A_popC"],
+        "subset_C_B_A_popA": {"population": "A", "node_id": [0, 1]},
+        "subset_C_B_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
+        "subset_C_B_A_popC": {"population": "C", "node_id": [0, 1, 4, 5]},
+    }
+    subset_C_A = {
+        "subset_C_A": ["subset_C_A_popA", "subset_C_A_popB", "subset_C_A_popC"],
+        "subset_C_A_popA": {"population": "A", "node_id": [1, 2]},
+        "subset_C_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
+        "subset_C_A_popC": {"population": "C", "node_id": [0, 1, 4, 5]},
+    }
+
+    circuit_config = str(SPLIT_SUBCIRCUIT_DATA_PATH / "circuit_config.json")
+
+    path_b_a = _split_custom_subcircuit(
+        tmp_path / "B_A", circuit_config, "subset_B_A", subset_B_A,
+        do_virtual=True, create_external=True
+    )
+
+    path_c_b_a = _split_custom_subcircuit(
+        tmp_path / "C_B_A", str(path_b_a / "circuit_config.json"),
+        "subset_C_B_A", subset_C_B_A,
+        do_virtual=True, create_external=True
+    )
+
+    path_c_a = _split_custom_subcircuit(
+        tmp_path / "C_A", circuit_config,
+        "subset_C_A", subset_C_A,
+        do_virtual=True, create_external=True
+    )

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -1026,51 +1026,51 @@ def _split_custom_subcircuit(output, circuit_config, node_set_name, node_set_def
 def test_subsubcircuit_virtual_operates_on_virtuals_only(tmp_path):
     """Test that do_virtual skips external populations in nested extraction.
 
-    Extracts B_A from A with do_virtual=True, create_external=True (so B_A has external_A).
-    Then extracts C_B_A from B_A with do_virtual=True, create_external=False.
+    Extracts c2_c1 from c1 with do_virtual=True, create_external=True (so c2_c1 has external_A).
+    Then extracts c3_c2_c1 from c2_c1 with do_virtual=True, create_external=False.
     Verifies that do_virtual does NOT process external_A (only genuine virtuals like V1).
-    Compares C_B_A against C_A (direct extraction from A) for equivalence.
+    Compares c3_c2_c1 against c3_c1 (direct extraction from c1) for equivalence.
     """
-    subset_B_A = {
-        "subset_B_A": ["subset_B_A_popA", "subset_B_A_popB", "subset_B_A_popC"],
-        "subset_B_A_popA": {"population": "A", "node_id": [1, 5]},
-        "subset_B_A_popB": {"population": "B", "node_id": [0, 1, 2, 3, 4, 5]},
-        "subset_B_A_popC": {"population": "C", "node_id": [0, 1, 2, 3, 4, 5]},
+    subset_c2_c1 = {
+        "subset_c2_c1": ["subset_c2_c1_popA", "subset_c2_c1_popB", "subset_c2_c1_popC"],
+        "subset_c2_c1_popA": {"population": "A", "node_id": [1, 5]},
+        "subset_c2_c1_popB": {"population": "B", "node_id": [0, 1, 2, 3, 4, 5]},
+        "subset_c2_c1_popC": {"population": "C", "node_id": [0, 1, 2, 3, 4, 5]},
     }
-    subset_C_B_A = {
-        "subset_C_B_A": ["subset_C_B_A_popA", "subset_C_B_A_popB", "subset_C_B_A_popC"],
-        "subset_C_B_A_popA": {"population": "A", "node_id": [0, 1]},
-        "subset_C_B_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
-        "subset_C_B_A_popC": {"population": "C", "node_id": [0, 1, 3, 4, 5]},
+    subset_c3_c2_c1 = {
+        "subset_c3_c2_c1": ["subset_c3_c2_c1_popA", "subset_c3_c2_c1_popB", "subset_c3_c2_c1_popC"],
+        "subset_c3_c2_c1_popA": {"population": "A", "node_id": [0, 1]},
+        "subset_c3_c2_c1_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
+        "subset_c3_c2_c1_popC": {"population": "C", "node_id": [0, 1, 3, 4, 5]},
     }
-    subset_C_A = {
-        "subset_C_A": ["subset_C_A_popA", "subset_C_A_popB", "subset_C_A_popC"],
-        "subset_C_A_popA": {"population": "A", "node_id": [1, 5]},
-        "subset_C_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
-        "subset_C_A_popC": {"population": "C", "node_id": [0, 1, 3, 4, 5]},
+    subset_c3_c1 = {
+        "subset_c3_c1": ["subset_c3_c1_popA", "subset_c3_c1_popB", "subset_c3_c1_popC"],
+        "subset_c3_c1_popA": {"population": "A", "node_id": [1, 5]},
+        "subset_c3_c1_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
+        "subset_c3_c1_popC": {"population": "C", "node_id": [0, 1, 3, 4, 5]},
     }
 
     circuit_config = str(SPLIT_SUBCIRCUIT_DATA_PATH / "circuit_config.json")
 
-    path_b_a = _split_custom_subcircuit(
-        tmp_path / "B_A", circuit_config, "subset_B_A", subset_B_A,
+    path_c2_c1 = _split_custom_subcircuit(
+        tmp_path / "c2_c1", circuit_config, "subset_c2_c1", subset_c2_c1,
         do_virtual=True, create_external=True
     )
 
-    path_c_b_a = _split_custom_subcircuit(
-        tmp_path / "C_B_A", str(path_b_a / "circuit_config.json"),
-        "subset_C_B_A", subset_C_B_A,
+    path_c3_c2_c1 = _split_custom_subcircuit(
+        tmp_path / "c3_c2_c1", str(path_c2_c1 / "circuit_config.json"),
+        "subset_c3_c2_c1", subset_c3_c2_c1,
         do_virtual=True, create_external=False
     )
 
-    path_c_a = _split_custom_subcircuit(
-        tmp_path / "C_A", circuit_config,
-        "subset_C_A", subset_C_A,
+    path_c3_c1 = _split_custom_subcircuit(
+        tmp_path / "c3_c1", circuit_config,
+        "subset_c3_c1", subset_c3_c1,
         do_virtual=True, create_external=False
     )
 
-    # --- Assertions for C_B_A ---
-    circ_c_b_a = bluepysnap.Circuit(str(path_c_b_a / "circuit_config.json"))
+    # --- Assertions for c3_c2_c1 ---
+    circ_c_b_a = bluepysnap.Circuit(str(path_c3_c2_c1 / "circuit_config.json"))
     node_pop_names = set(circ_c_b_a.nodes.keys())
 
     # do_virtual should NOT have processed external_A (it's not a genuine virtual)
@@ -1080,17 +1080,17 @@ def test_subsubcircuit_virtual_operates_on_virtuals_only(tmp_path):
 
     # Genuine virtuals should be processed correctly
     assert "V1" in node_pop_names, "V1 (genuine virtual) should be extracted"
-    assert "V2" not in node_pop_names, "V2 should be dropped (its target is outside C_B_A)"
+    assert "V2" not in node_pop_names, "V2 should be dropped (its target is outside c3_c2_c1)"
 
-    # C_A and C_B_A should be equivalent
-    _assert_circuits_equal(path_c_a, path_c_b_a, True)
+    # c3_c1 and c3_c2_c1 should be equivalent
+    _assert_circuits_equal(path_c3_c1, path_c3_c2_c1, True)
 
 
 def test_subsubcircuit_externals_merge(tmp_path):
     """Nested extraction with create_external merges external populations correctly.
 
-    Verifies that extracting C from B (from A) produces the same result as
-    extracting C directly from A, up to 3 levels of nesting (D).
+    Verifies that extracting c3 from c2 (from c1) produces the same result as
+    extracting c3 directly from c1, up to 3 levels of nesting (c4).
     """
     ### Nomenclature:
     # X_Y: circuit X derived from parent Y.
@@ -1099,80 +1099,80 @@ def test_subsubcircuit_externals_merge(tmp_path):
     # Virtual nodes are kept only if they have at least one edge to a kept
     # biophysical node; otherwise they are dropped.
 
-    # B_A from A: keep A:{1,2,3,5}, B:all, C:all
+    # c2_c1 from A: keep A:{1,2,3,5}, B:all, C:all
     # - external_A: {0, 4}
     # - discarded: A:{} (none)
     # - V1 kept: {1,2}. V1 dropped: {0,3}
     # - V2 kept: {0}
-    subset_B_A = {
-        "subset_B_A": ["subset_B_A_popA", "subset_B_A_popB", "subset_B_A_popC"],
-        "subset_B_A_popA": {"population": "A", "node_id": [1, 2, 3, 5]},
-        "subset_B_A_popB": {"population": "B", "node_id": [0, 1, 2, 3, 4, 5]},
-        "subset_B_A_popC": {"population": "C", "node_id": [0, 1, 2, 3, 4, 5]},
+    subset_c2_c1 = {
+        "subset_c2_c1": ["subset_c2_c1_popA", "subset_c2_c1_popB", "subset_c2_c1_popC"],
+        "subset_c2_c1_popA": {"population": "A", "node_id": [1, 2, 3, 5]},
+        "subset_c2_c1_popB": {"population": "B", "node_id": [0, 1, 2, 3, 4, 5]},
+        "subset_c2_c1_popC": {"population": "C", "node_id": [0, 1, 2, 3, 4, 5]},
     }
-    # C_A from A: keep A:{1,2,3}, B:{1,2,3,4,5}, C:{0,1,2,5}
+    # c3_c1 from A: keep A:{1,2,3}, B:{1,2,3,4,5}, C:{0,1,2,5}
     # - external_A: {0, 5}. Discarded A: {4}
     # - external_C: {3}. Discarded C: {4}
     # - discarded B: {0}
     # - V1 kept: {1}. V1 dropped: {2}
     # - V2 kept: {0}
-    subset_C_A = {
-        "subset_C_A": ["subset_C_A_popA", "subset_C_A_popB", "subset_C_A_popC"],
-        "subset_C_A_popA": {"population": "A", "node_id": [1, 2, 3]},
-        "subset_C_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
-        "subset_C_A_popC": {"population": "C", "node_id": [0, 1, 2, 5]},
+    subset_c3_c1 = {
+        "subset_c3_c1": ["subset_c3_c1_popA", "subset_c3_c1_popB", "subset_c3_c1_popC"],
+        "subset_c3_c1_popA": {"population": "A", "node_id": [1, 2, 3]},
+        "subset_c3_c1_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
+        "subset_c3_c1_popC": {"population": "C", "node_id": [0, 1, 2, 5]},
     }
-    # D_A from A: keep A:{1,2}, B:{1,3,4}, C:{0,1,2,5}
+    # c4_c1 from A: keep A:{1,2}, B:{1,3,4}, C:{0,1,2,5}
     # - external_A: {3, 5}. Discarded A: {0, 4}
     # - external_B: {2}. Discarded B: {0, 5}
     # - external_C: {3}. Discarded C: {4}
     # - V1 kept: {1}. V1 dropped: {2}
     # - V2 kept: {0}
-    subset_D_A = {
-        "subset_D_A": ["subset_D_A_popA", "subset_D_A_popB", "subset_D_A_popC"],
-        "subset_D_A_popA": {"population": "A", "node_id": [1, 2]},
-        "subset_D_A_popB": {"population": "B", "node_id": [1, 3, 4]},
-        "subset_D_A_popC": {"population": "C", "node_id": [0, 1, 2, 5]},
+    subset_c4_c1 = {
+        "subset_c4_c1": ["subset_c4_c1_popA", "subset_c4_c1_popB", "subset_c4_c1_popC"],
+        "subset_c4_c1_popA": {"population": "A", "node_id": [1, 2]},
+        "subset_c4_c1_popB": {"population": "B", "node_id": [1, 3, 4]},
+        "subset_c4_c1_popC": {"population": "C", "node_id": [0, 1, 2, 5]},
     }
-    # C_B_A from B_A (parent has A:local{0,1,2,3}=orig{1,2,3,5}, external_A:orig{0,4}):
+    # c3_c2_c1 from c2_c1 (parent has A:local{0,1,2,3}=orig{1,2,3,5}, external_A:orig{0,4}):
     # - Remove A:local{2} (orig 3) -> merges into external_A
     # - Remove B:{0} -> discarded
     # - Remove C:{3,4} -> C:3 external_C, C:4 discarded
-    # Result should equal C_A
-    subset_C_B_A = {
-        "subset_C_B_A": ["subset_C_B_A_popA", "subset_C_B_A_popB", "subset_C_B_A_popC"],
-        "subset_C_B_A_popA": {"population": "A", "node_id": [0, 1, 2]},
-        "subset_C_B_A_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
-        "subset_C_B_A_popC": {"population": "C", "node_id": [0, 1, 2, 5]},
+    # Result should equal c3_c1
+    subset_c3_c2_c1 = {
+        "subset_c3_c2_c1": ["subset_c3_c2_c1_popA", "subset_c3_c2_c1_popB", "subset_c3_c2_c1_popC"],
+        "subset_c3_c2_c1_popA": {"population": "A", "node_id": [0, 1, 2]},
+        "subset_c3_c2_c1_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
+        "subset_c3_c2_c1_popC": {"population": "C", "node_id": [0, 1, 2, 5]},
     }
-    # D_B_A from B_A (parent has A:local{0,1,2,3}=orig{1,2,3,5}, external_A:orig{0,4}):
+    # c4_c2_c1 from c2_c1 (parent has A:local{0,1,2,3}=orig{1,2,3,5}, external_A:orig{0,4}):
     # - Remove A:local{1,2} (orig 2,3) -> A:2(orig 3) merges into external_A, A:1(orig 2) discarded
     # - Remove B:{0,2,5} -> B:2 external_B, rest discarded
     # - Remove C:{3,4} -> C:3 external_C, C:4 discarded
-    # Result should equal D_A
-    subset_D_B_A = {
-        "subset_D_B_A": ["subset_D_B_A_popA", "subset_D_B_A_popB", "subset_D_B_A_popC"],
-        "subset_D_B_A_popA": {"population": "A", "node_id": [0, 1]},
-        "subset_D_B_A_popB": {"population": "B", "node_id": [1, 3, 4]},
-        "subset_D_B_A_popC": {"population": "C", "node_id": [0, 1, 2, 5]},
+    # Result should equal c4_c1
+    subset_c4_c2_c1 = {
+        "subset_c4_c2_c1": ["subset_c4_c2_c1_popA", "subset_c4_c2_c1_popB", "subset_c4_c2_c1_popC"],
+        "subset_c4_c2_c1_popA": {"population": "A", "node_id": [0, 1]},
+        "subset_c4_c2_c1_popB": {"population": "B", "node_id": [1, 3, 4]},
+        "subset_c4_c2_c1_popC": {"population": "C", "node_id": [0, 1, 2, 5]},
     }
-    # D_C_A from C_A (parent has A:local{0,1,2}=orig{1,2,3}, external_A:orig{0,5}):
+    # c4_c3_c1 from c3_c1 (parent has A:local{0,1,2}=orig{1,2,3}, external_A:orig{0,5}):
     # - Remove A:local{2} (orig 3) -> merges into external_A
     # - Remove B:local{1,4} (orig 2,5) -> B:1(orig 2) external_B, B:4(orig 5) discarded
-    # Result should equal D_A
-    subset_D_C_A = {
-        "subset_D_C_A": ["subset_D_C_A_popA", "subset_D_C_A_popB", "subset_D_C_A_popC"],
-        "subset_D_C_A_popA": {"population": "A", "node_id": [0, 1]},
-        "subset_D_C_A_popB": {"population": "B", "node_id": [0, 2, 3]},
-        "subset_D_C_A_popC": {"population": "C", "node_id": [0, 1, 2, 3]},
+    # Result should equal c4_c1
+    subset_c4_c3_c1 = {
+        "subset_c4_c3_c1": ["subset_c4_c3_c1_popA", "subset_c4_c3_c1_popB", "subset_c4_c3_c1_popC"],
+        "subset_c4_c3_c1_popA": {"population": "A", "node_id": [0, 1]},
+        "subset_c4_c3_c1_popB": {"population": "B", "node_id": [0, 2, 3]},
+        "subset_c4_c3_c1_popC": {"population": "C", "node_id": [0, 1, 2, 3]},
     }
-    # D_C_B_A from C_B_A (same original content as C_A):
-    # - Same removals as D_C_A. Result should equal D_A
-    subset_D_C_B_A = {
-        "subset_D_C_B_A": ["subset_D_C_B_A_popA", "subset_D_C_B_A_popB", "subset_D_C_B_A_popC"],
-        "subset_D_C_B_A_popA": {"population": "A", "node_id": [0, 1]},
-        "subset_D_C_B_A_popB": {"population": "B", "node_id": [0, 2, 3]},
-        "subset_D_C_B_A_popC": {"population": "C", "node_id": [0, 1, 2, 3]},
+    # c4_c3_c2_c1 from c3_c2_c1 (same original content as c3_c1):
+    # - Same removals as c4_c3_c1. Result should equal c4_c1
+    subset_c4_c3_c2_c1 = {
+        "subset_c4_c3_c2_c1": ["subset_c4_c3_c2_c1_popA", "subset_c4_c3_c2_c1_popB", "subset_c4_c3_c2_c1_popC"],
+        "subset_c4_c3_c2_c1_popA": {"population": "A", "node_id": [0, 1]},
+        "subset_c4_c3_c2_c1_popB": {"population": "B", "node_id": [0, 2, 3]},
+        "subset_c4_c3_c2_c1_popC": {"population": "C", "node_id": [0, 1, 2, 3]},
     }
 
 
@@ -1180,52 +1180,52 @@ def test_subsubcircuit_externals_merge(tmp_path):
 
     circuit_config = str(SPLIT_SUBCIRCUIT_DATA_PATH / "circuit_config.json")
 
-    path_b_a = _split_custom_subcircuit(
-        tmp_path / "B_A", circuit_config, "subset_B_A", subset_B_A,
+    path_c2_c1 = _split_custom_subcircuit(
+        tmp_path / "c2_c1", circuit_config, "subset_c2_c1", subset_c2_c1,
         do_virtual=True, create_external=True
     )
 
-    path_c_b_a = _split_custom_subcircuit(
-        tmp_path / "C_B_A", str(path_b_a / "circuit_config.json"),
-        "subset_C_B_A", subset_C_B_A,
+    path_c3_c2_c1 = _split_custom_subcircuit(
+        tmp_path / "c3_c2_c1", str(path_c2_c1 / "circuit_config.json"),
+        "subset_c3_c2_c1", subset_c3_c2_c1,
         do_virtual=True, create_external=True
     )
 
-    path_c_a = _split_custom_subcircuit(
-        tmp_path / "C_A", circuit_config,
-        "subset_C_A", subset_C_A,
+    path_c3_c1 = _split_custom_subcircuit(
+        tmp_path / "c3_c1", circuit_config,
+        "subset_c3_c1", subset_c3_c1,
         do_virtual=True, create_external=True
     )
 
-    path_d_a = _split_custom_subcircuit(
-        tmp_path / "D_A", circuit_config,
-        "subset_D_A", subset_D_A,
+    path_c4_c1 = _split_custom_subcircuit(
+        tmp_path / "c4_c1", circuit_config,
+        "subset_c4_c1", subset_c4_c1,
         do_virtual=True, create_external=True
     )
 
-    path_d_b_a = _split_custom_subcircuit(
-        tmp_path / "D_B_A", str(path_b_a / "circuit_config.json"),
-        "subset_D_B_A", subset_D_B_A,
+    path_c4_c2_c1 = _split_custom_subcircuit(
+        tmp_path / "c4_c2_c1", str(path_c2_c1 / "circuit_config.json"),
+        "subset_c4_c2_c1", subset_c4_c2_c1,
         do_virtual=True, create_external=True
     )
 
-    path_d_c_a = _split_custom_subcircuit(
-        tmp_path / "D_C_A", str(path_c_a / "circuit_config.json"),
-        "subset_D_C_A", subset_D_C_A,
+    path_c4_c3_c1 = _split_custom_subcircuit(
+        tmp_path / "c4_c3_c1", str(path_c3_c1 / "circuit_config.json"),
+        "subset_c4_c3_c1", subset_c4_c3_c1,
         do_virtual=True, create_external=True
     )
 
-    path_d_c_b_a = _split_custom_subcircuit(
-        tmp_path / "D_C_B_A", str(path_c_b_a / "circuit_config.json"),
-        "subset_D_C_B_A", subset_D_C_B_A,
+    path_c4_c3_c2_c1 = _split_custom_subcircuit(
+        tmp_path / "c4_c3_c2_c1", str(path_c3_c2_c1 / "circuit_config.json"),
+        "subset_c4_c3_c2_c1", subset_c4_c3_c2_c1,
         do_virtual=True, create_external=True
     )
 
 
     # All C circuits should be equal
-    _assert_circuits_equal(path_c_a, path_c_b_a)
+    _assert_circuits_equal(path_c3_c1, path_c3_c2_c1)
 
     # All D circuits should be equal
-    _assert_circuits_equal(path_d_a, path_d_b_a)
-    _assert_circuits_equal(path_d_a, path_d_c_a)
-    _assert_circuits_equal(path_d_a, path_d_c_b_a)
+    _assert_circuits_equal(path_c4_c1, path_c4_c2_c1)
+    _assert_circuits_equal(path_c4_c1, path_c4_c3_c1)
+    _assert_circuits_equal(path_c4_c1, path_c4_c3_c2_c1)

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -883,12 +883,10 @@ def test_copy_filtered_edges_advanced(tmp_path):
         h5_read_chunk_size=3,  # FORCE chunking
         edge_type="synapse_astrocyte"
     )
-    with h5py.File(write_edge_config.output_path, "w") as h5out:
-        split_population._copy_filtered_edges(
-            h5out=h5out,
-            write_edge_config=write_edge_config,
-            edge_mappings=edge_mappings
-        )
+    split_population._copy_filtered_edges(
+        write_edge_config=write_edge_config,
+        edge_mappings=edge_mappings
+    )
 
     # Verification
     keep, new_name = edge_mappings["orig_src_edge_pop"]

--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,6 @@ convention = google
 
 [gh-actions]
 python =
-  3.10: py310, lint, coverage
+  3.10: py310, coverage
   3.11: py311, check-packaging
-  3.12: py312, docs
+  3.12: py312, lint, docs

--- a/viz_circuits.sh
+++ b/viz_circuits.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Viz all circuits from test_subsubcircuit_externals_merge
+# Usage: ./viz_circuits.sh
+
+set -e
+
+BASE="removeme/test_subsubcircuit_externals_m0"
+BB="venv/bin/brainbuilder"
+
+rm -rf removeme
+venv/bin/tox -e py312 -- tests/unit/test_sonata/test_split_population.py::test_subsubcircuit_externals_merge --basetemp=removeme -vv
+
+$BB sonata visualize tests/unit/data/sonata/split_subcircuit/circuit_config.json --title "Original (A)"
+
+for dir in "$BASE"/*/; do
+    name=$(basename "$dir")
+    [[ "$name" == *_fixture ]] && continue
+    config="$dir/circuit_config.json"
+    if [ -f "$config" ]; then
+        $BB sonata visualize "$config" --title "$name"
+    fi
+done


### PR DESCRIPTION
## Context

This is a reference to be split in multiple sub-issues. DO NOT MERGE

fix: https://github.com/openbraininstitute/prod-build-circuit/issues/14

## Test

Since it is easy to lose track of the explanations in the issue I focused on the circuit in `tests/unit/data/sonata/split_subcircuit` and on these extractions:

```
    subset_B_A = {
        "subset_B_A": ["subset_B_A_popA", "subset_B_A_popB", "subset_B_A_popC"],
        "subset_B_A_popA": {"population": "A", "node_id": [0, 2, 4, 5]},
        "subset_B_A_popB": {"population": "B", "node_id": [0, 2, 4, 5]},
        "subset_B_A_popC": {"population": "C", "node_id": [0, 2, 4, 5]},
    }
    # subset_C_A picks A:{0,2}, B:{0,2}, C:{0,2} from A
    subset_C_A = {
        "subset_C_A": ["subset_C_A_popA", "subset_C_A_popB", "subset_C_A_popC"],
        "subset_C_A_popA": {"population": "A", "node_id": [2, 5]},
        "subset_C_A_popB": {"population": "B", "node_id": [0, 2, 4, 5]},
        "subset_C_A_popC": {"population": "C", "node_id": [0, 2, 4, 5]},
    }
    # subset_C_B_A picks A:{0,1}, B:{0,1}, C:{0,1} from B_A (renumbered IDs of original {0,2})
    subset_C_B_A = {
        "subset_C_B_A": ["subset_C_B_A_popA", "subset_C_B_A_popB", "subset_C_B_A_popC"],
        "subset_C_B_A_popA": {"population": "A", "node_id": [1, 3]},
        "subset_C_B_A_popB": {"population": "B", "node_id": [0, 1, 2, 3]},
        "subset_C_B_A_popC": {"population": "C", "node_id": [0, 1, 2, 3]},
    }
```

With the convention: `B_A` means subcircuit B extracted from A. I also created a nice viz tool to understanding at first glance what is going on. Here is the initial state of the art:

<img width="1291" height="725" alt="Screenshot 2026-05-08 at 12 38 28" src="https://github.com/user-attachments/assets/1697e498-72c1-4b9f-bd8c-928c54f00a83" />

**Objective:** the last 2 graphs should be the same (apart numbering)

