### PR TITLE
Fix external nodes file missing merged IDs from multiple edges (2)

### DIFF
--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -944,18 +944,15 @@ def _write_subcircuit_external(
             )
             write_edge_configs.append(write_edge_config)
 
-            new_nodes[new_source_pop_name] = (
-                edge.source.name,
-                wanted_src_ids.index.to_numpy(),
-            )
+            new_nodes[new_source_pop_name] = edge.source.name
 
     new_edges_files = _orchestrate_write_subcircuit_edges(write_edge_configs=write_edge_configs)
 
     new_node_files = {}
     # write new virtual nodes from originally non-virtual populations
-    for population_name, id_tuple in new_nodes.items():
-        # Get all properties of the subset of the node population that is relevant
-        orig_population_name, ids = id_tuple
+    for population_name, orig_population_name in new_nodes.items():
+        # Use the accumulated id_mapping (which merges IDs across all edges)
+        ids = id_mapping[population_name].index.to_numpy()
         df = circuit.nodes[orig_population_name].get(ids).reset_index(drop=True)
         nodes_path = Path(output) / population_name / "nodes.h5"
         nodes_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -978,3 +978,45 @@ def test_external_no_nan_when_no_overlap_between_batches(tmp_path):
     )
     # new_ids should be contiguous starting from 0
     assert ext_a["new_id"] == list(range(len(ext_a["new_id"])))
+
+
+def test_external_nodes_file_contains_all_merged_ids(tmp_path):
+    """Test that external nodes.h5 contains IDs from ALL edges, not just the last.
+
+    The bug: new_nodes dict was overwritten on each edge iteration, so only the
+    last edge's source IDs were written to nodes.h5. The fix uses the accumulated
+    id_mapping index instead.
+
+    Uses the same disjoint-batch scenario as the NaN test:
+    - A__B contributes external node 0
+    - A__C contributes external nodes 3, 4
+    The nodes.h5 must contain all 3 nodes, not just {3, 4} from the last edge.
+    """
+    node_set_def = {
+        "merge_trigger": ["merge_trigger_popA", "merge_trigger_popB", "merge_trigger_popC"],
+        "merge_trigger_popA": {"population": "A", "node_id": [5]},
+        "merge_trigger_popB": {"population": "B", "node_id": [0, 1, 2, 3, 4, 5]},
+        "merge_trigger_popC": {"population": "C", "node_id": [0, 1, 2, 3, 4, 5]},
+    }
+
+    circuit_config = str(SPLIT_SUBCIRCUIT_DATA_PATH / "circuit_config.json")
+
+    output = _split_custom_subcircuit(
+        tmp_path / "out", circuit_config, "merge_trigger", node_set_def,
+        do_virtual=False, create_external=True
+    )
+
+    # id_mapping should have all 3 external nodes
+    mapping = load_json(output / "id_mapping.json")
+    ext_a = mapping["external_A"]
+    assert len(ext_a["parent_id"]) == 3, (
+        f"Expected 3 external nodes, got {len(ext_a['parent_id'])}: {ext_a['parent_id']}"
+    )
+
+    # The nodes.h5 file must contain the same number of nodes as the id_mapping
+    with h5py.File(output / "external_A" / "nodes.h5", "r") as h5:
+        node_count = len(h5["nodes/external_A/0/model_type"])
+        assert node_count == 3, (
+            f"nodes.h5 has {node_count} nodes but id_mapping has 3. "
+            "Nodes file is missing merged IDs from multiple edges."
+        )

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -981,16 +981,12 @@ def test_external_no_nan_when_no_overlap_between_batches(tmp_path):
 
 
 def test_external_nodes_file_contains_all_merged_ids(tmp_path):
-    """Test that external nodes.h5 contains IDs from ALL edges, not just the last.
+    """Test that external nodes.h5 contains IDs from all edges.
 
-    The bug: new_nodes dict was overwritten on each edge iteration, so only the
-    last edge's source IDs were written to nodes.h5. The fix uses the accumulated
-    id_mapping index instead.
-
-    Uses the same disjoint-batch scenario as the NaN test:
+    Scenario (same disjoint-batch setup as the NaN test):
     - A__B contributes external node 0
     - A__C contributes external nodes 3, 4
-    The nodes.h5 must contain all 3 nodes, not just {3, 4} from the last edge.
+    The nodes.h5 must contain all 3 external nodes.
     """
     node_set_def = {
         "merge_trigger": ["merge_trigger_popA", "merge_trigger_popB", "merge_trigger_popC"],
@@ -1006,17 +1002,15 @@ def test_external_nodes_file_contains_all_merged_ids(tmp_path):
         do_virtual=False, create_external=True
     )
 
-    # id_mapping should have all 3 external nodes
     mapping = load_json(output / "id_mapping.json")
     ext_a = mapping["external_A"]
     assert len(ext_a["parent_id"]) == 3, (
         f"Expected 3 external nodes, got {len(ext_a['parent_id'])}: {ext_a['parent_id']}"
     )
 
-    # The nodes.h5 file must contain the same number of nodes as the id_mapping
+    # nodes.h5 must be consistent with id_mapping
     with h5py.File(output / "external_A" / "nodes.h5", "r") as h5:
         node_count = len(h5["nodes/external_A/0/model_type"])
         assert node_count == 3, (
-            f"nodes.h5 has {node_count} nodes but id_mapping has 3. "
-            "Nodes file is missing merged IDs from multiple edges."
+            f"nodes.h5 has {node_count} nodes but id_mapping has 3"
         )

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -983,7 +983,7 @@ def test_external_no_nan_when_no_overlap_between_batches(tmp_path):
 def test_external_nodes_file_contains_all_merged_ids(tmp_path):
     """Test that external nodes.h5 contains IDs from all edges.
 
-    Scenario (same disjoint-batch setup as the NaN test):
+    Scenario (same disjoint-batch setup as test_external_no_nan_when_no_overlap_between_batches):
     - A__B contributes external node 0
     - A__C contributes external nodes 3, 4
     The nodes.h5 must contain all 3 external nodes.


### PR DESCRIPTION
The new_nodes dict was overwritten on each edge iteration, so only the last edge's source IDs were written to the nodes.h5 file. Use the accumulated id_mapping index instead, which correctly merges IDs across all edges sharing the same external source population.