### PR TITLE
Remove model_template from virtual populations during extraction

### DIFF
--- a/brainbuilder/utils/sonata/curate.py
+++ b/brainbuilder/utils/sonata/curate.py
@@ -225,8 +225,6 @@ def _create_source_nodes(population_name, size, output_dir):
     L.debug("_create_source_nodes: %s(%d)", population_name, size)
     cells = voxcell.CellCollection()
     cells.properties["model_type"] = ["virtual"] * size
-    # '' stands for NULL value in SONATA https://github.com/AllenInstitute/sonata/issues/122
-    cells.properties["model_template"] = [""] * size
     cells.population_name = population_name
     output = output_dir / f"nodes_{population_name}.h5"
     cells.save(output)

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -170,13 +170,14 @@ def _drop_column_with_warning(df: pd.DataFrame, column: str, population_name: st
     """
     if column not in df.columns:
         return df
-    non_empty = df[column][df[column].str.len() > 0]
-    if not non_empty.empty:
-        L.warning(
-            "Population '%s': '%s' has non-empty values that will be dropped: %s",
-            population_name,
-            column,
-            non_empty.unique().tolist(),
+      has_content = df[column].str.len() > 0
+      if has_content.any():
+          L.warning(
+              "Population '%s': '%s' has non-empty values that will be dropped: %s",
+              population_name,
+              column,
+              df[column][has_content].unique().tolist(),
+          )
         )
     return df.drop(columns=[column])
 

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -1280,6 +1280,16 @@ def split_subcircuit(
     # Write virtual nodes
     for population_name, ids in virt_node_ids.items():
         df = circuit.nodes[population_name].get(ids)
+        if "model_template" in df.columns:
+            non_empty = df["model_template"].replace("", pd.NA).dropna()
+            if not non_empty.empty:
+                L.warning(
+                    "Population '%s': 'model_template' has non-empty values for virtual nodes"
+                    " and will be ignored: %s",
+                    population_name,
+                    non_empty.unique().tolist(),
+                )
+            df = df.drop(columns=["model_template"])
         nodes_path = Path(output) / population_name / "nodes.h5"
         new_node_files[population_name] = _save_sonata_nodes(nodes_path, df, population_name)
 
@@ -1288,6 +1298,16 @@ def split_subcircuit(
         if population_name in ext_nodes:
             continue  # Nodes will be written from the merged id_mapping below
         df = circuit.nodes[population_name].get(ids)
+        if "model_template" in df.columns:
+            non_empty = df["model_template"].replace("", pd.NA).dropna()
+            if not non_empty.empty:
+                L.warning(
+                    "Population '%s': 'model_template' has non-empty values for virtual nodes"
+                    " and will be ignored: %s",
+                    population_name,
+                    non_empty.unique().tolist(),
+                )
+            df = df.drop(columns=["model_template"])
         nodes_path = Path(output) / population_name / "nodes.h5"
         new_node_files[population_name] = _save_sonata_nodes(nodes_path, df, population_name)
 
@@ -1298,6 +1318,8 @@ def split_subcircuit(
             source_ids = df.index.to_numpy()
             frames.append(circuit.nodes[source_pop].get(source_ids))
         combined_df = pd.concat(frames)
+        if "model_template" in combined_df.columns:
+            combined_df = combined_df.drop(columns=["model_template"])
         nodes_path = Path(output) / population_name / "nodes.h5"
         new_node_files[population_name] = _save_sonata_nodes(
             nodes_path, combined_df, population_name

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -157,6 +157,30 @@ def _load_sonata_nodes(nodes_path):
     return df
 
 
+def _drop_column_with_warning(df: pd.DataFrame, column: str, population_name: str) -> pd.DataFrame:
+    """Drop a column from a DataFrame, warning if it contains non-empty values.
+
+    Args:
+        df: DataFrame to modify.
+        column: Column name to drop.
+        population_name: Population name for the warning message.
+
+    Returns:
+        DataFrame with the column removed, or unchanged if column is absent.
+    """
+    if column not in df.columns:
+        return df
+    non_empty = df[column][df[column].str.len() > 0]
+    if not non_empty.empty:
+        L.warning(
+            "Population '%s': '%s' has non-empty values that will be dropped: %s",
+            population_name,
+            column,
+            non_empty.unique().tolist(),
+        )
+    return df.drop(columns=[column])
+
+
 def _save_sonata_nodes(nodes_path, df, population_name):
     """Save a dataframe of nodes (0-based IDs) to sonata file.
 
@@ -1280,16 +1304,7 @@ def split_subcircuit(
     # Write virtual nodes
     for population_name, ids in virt_node_ids.items():
         df = circuit.nodes[population_name].get(ids)
-        if "model_template" in df.columns:
-            non_empty = df["model_template"].replace("", pd.NA).dropna()
-            if not non_empty.empty:
-                L.warning(
-                    "Population '%s': 'model_template' has non-empty values for virtual nodes"
-                    " and will be ignored: %s",
-                    population_name,
-                    non_empty.unique().tolist(),
-                )
-            df = df.drop(columns=["model_template"])
+        df = _drop_column_with_warning(df, "model_template", population_name)
         nodes_path = Path(output) / population_name / "nodes.h5"
         new_node_files[population_name] = _save_sonata_nodes(nodes_path, df, population_name)
 
@@ -1298,16 +1313,7 @@ def split_subcircuit(
         if population_name in ext_nodes:
             continue  # Nodes will be written from the merged id_mapping below
         df = circuit.nodes[population_name].get(ids)
-        if "model_template" in df.columns:
-            non_empty = df["model_template"].replace("", pd.NA).dropna()
-            if not non_empty.empty:
-                L.warning(
-                    "Population '%s': 'model_template' has non-empty values for virtual nodes"
-                    " and will be ignored: %s",
-                    population_name,
-                    non_empty.unique().tolist(),
-                )
-            df = df.drop(columns=["model_template"])
+        df = _drop_column_with_warning(df, "model_template", population_name)
         nodes_path = Path(output) / population_name / "nodes.h5"
         new_node_files[population_name] = _save_sonata_nodes(nodes_path, df, population_name)
 
@@ -1318,8 +1324,7 @@ def split_subcircuit(
             source_ids = df.index.to_numpy()
             frames.append(circuit.nodes[source_pop].get(source_ids))
         combined_df = pd.concat(frames)
-        if "model_template" in combined_df.columns:
-            combined_df = combined_df.drop(columns=["model_template"])
+        combined_df = _drop_column_with_warning(combined_df, "model_template", population_name)
         nodes_path = Path(output) / population_name / "nodes.h5"
         new_node_files[population_name] = _save_sonata_nodes(
             nodes_path, combined_df, population_name

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -170,14 +170,13 @@ def _drop_column_with_warning(df: pd.DataFrame, column: str, population_name: st
     """
     if column not in df.columns:
         return df
-      has_content = df[column].str.len() > 0
-      if has_content.any():
-          L.warning(
-              "Population '%s': '%s' has non-empty values that will be dropped: %s",
-              population_name,
-              column,
-              df[column][has_content].unique().tolist(),
-          )
+    has_content = df[column].str.len() > 0
+    if has_content.any():
+        L.warning(
+            "Population '%s': '%s' has non-empty values that will be dropped: %s",
+            population_name,
+            column,
+            df[column][has_content].unique().tolist(),
         )
     return df.drop(columns=[column])
 

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -727,6 +727,56 @@ def test_split_subcircuit_strips_model_template_from_externals(tmp_path):
         assert "model_type" in h5["nodes/external_B/0"]
 
 
+def test_split_subcircuit_strips_model_template_from_legacy_externals(tmp_path):
+    """model_template should be stripped from pre-existing external populations (legacy files).
+
+    Simulates a legacy circuit where external nodes still carry model_template
+    (created before the stripping logic existed). Extracts a sub-subcircuit and
+    verifies model_template is removed from the carried-forward external population.
+    """
+    # Step 1: Extract with create_external to get a circuit with external_A
+    c1_output = tmp_path / "c1"
+    split_population.split_subcircuit(
+        c1_output,
+        "mtype_a",
+        str(SPLIT_SUBCIRCUIT_DATA_PATH / "circuit_config.json"),
+        do_virtual=False,
+        create_external=True,
+    )
+
+    # Step 2: Inject model_template into external_A to simulate a legacy file
+    ext_a_path = c1_output / "external_A" / "nodes.h5"
+    with h5py.File(ext_a_path, "a") as h5:
+        n_nodes = len(h5["nodes/external_A/0/model_type"])
+        h5.create_dataset(
+            "/nodes/external_A/0/model_template", data=["hoc:legacy"] * n_nodes
+        )
+
+    # Step 3: Re-extract from c1, keeping all biophysical A nodes so external_A
+    # passes through the existing-external path (not merged with new externals).
+    # Remove one B node to make create_external meaningful.
+    node_set_def = {
+        "legacy_test": ["legacy_test_popA", "legacy_test_popB", "legacy_test_popC"],
+        "legacy_test_popA": {"population": "A", "node_id": [0, 1, 2]},
+        "legacy_test_popB": {"population": "B", "node_id": [1, 2, 3, 4, 5]},
+        "legacy_test_popC": {"population": "C", "node_id": [0, 1, 2, 3, 4, 5]},
+    }
+
+    c2_output = _split_custom_subcircuit(
+        tmp_path / "c2",
+        str(c1_output / "circuit_config.json"),
+        "legacy_test",
+        node_set_def,
+        do_virtual=False,
+        create_external=True,
+    )
+
+    # Step 4: Verify model_template is stripped from the carried-forward external_A
+    with h5py.File(c2_output / "external_A" / "nodes.h5", "r") as h5:
+        assert "model_template" not in h5["nodes/external_A/0"]
+        assert "model_type" in h5["nodes/external_A/0"]
+
+
 @pytest.mark.parametrize(
     "circuit,from_subcircuit",
     [

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -673,6 +673,60 @@ def test_split_subcircuit_with_virtual(tmp_path, circuit, from_subcircuit):
     assert virtual_pop == {"V2__C": {"type": "chemical"}}
 
 
+def test_split_subcircuit_strips_model_template_from_virtual(tmp_path):
+    """model_template should be stripped from virtual populations during extraction."""
+    # Copy fixture and inject model_template into virtual node files
+    fixture = tmp_path / "fixture"
+    shutil.copytree(SPLIT_SUBCIRCUIT_DATA_PATH, fixture)
+
+    # Add model_template with empty strings to V1 (backward-compat case)
+    with h5py.File(fixture / "networks/nodes/virtual_nodes_V1.h5", "a") as h5:
+        h5.create_dataset("/nodes/V1/0/model_template", data=[""] * 4)
+
+    # Add model_template with non-empty values to V2 (should trigger warning)
+    with h5py.File(fixture / "networks/nodes/virtual_nodes_V2.h5", "a") as h5:
+        h5.create_dataset("/nodes/V2/0/model_template", data=["hoc:unexpected"])
+
+    output = tmp_path / "output"
+    split_population.split_subcircuit(
+        output,
+        "mtype_a",
+        str(fixture / "circuit_config.json"),
+        do_virtual=True,
+        create_external=False,
+    )
+
+    # Verify model_template is absent from all extracted virtual populations
+    with h5py.File(output / "V1" / "nodes.h5", "r") as h5:
+        assert "model_template" not in h5["nodes/V1/0"]
+        assert "model_type" in h5["nodes/V1/0"]
+
+    with h5py.File(output / "V2" / "nodes.h5", "r") as h5:
+        assert "model_template" not in h5["nodes/V2/0"]
+        assert "model_type" in h5["nodes/V2/0"]
+
+
+def test_split_subcircuit_strips_model_template_from_externals(tmp_path):
+    """model_template should be stripped from newly-externalized populations."""
+    output = tmp_path / "output"
+    split_population.split_subcircuit(
+        output,
+        "mtype_a",
+        str(SPLIT_SUBCIRCUIT_DATA_PATH / "circuit_config.json"),
+        do_virtual=False,
+        create_external=True,
+    )
+
+    # external_A nodes are biophysical nodes turned virtual — model_template must be gone
+    with h5py.File(output / "external_A/nodes.h5", "r") as h5:
+        assert "model_template" not in h5["nodes/external_A/0"]
+        assert "model_type" in h5["nodes/external_A/0"]
+
+    with h5py.File(output / "external_B/nodes.h5", "r") as h5:
+        assert "model_template" not in h5["nodes/external_B/0"]
+        assert "model_type" in h5["nodes/external_B/0"]
+
+
 @pytest.mark.parametrize(
     "circuit,from_subcircuit",
     [


### PR DESCRIPTION
Virtual populations have a `model_template` column filled with empty strings. This column has no meaning for virtual nodes and clutters the table view of neuron properties.

- If the column contains non-empty values on a virtual population → emit a warning, then drop it.
- If the column is all empty strings → silently drop it (backward-compatible, no noise).
- For newly-externalized nodes (biophysical → virtual conversion) → silently drop it (non-empty values are expected from the biophysical source).
- add tests

## Issues

Originally required in: [# Make `model_template` optional for virtual populations](https://github.com/openbraininstitute/prod-build-circuit/issues/34)

Fix: https://github.com/openbraininstitute/brainbuilder/issues/57
