### PR TITLE
Preserve categorical node properties when extracting subcircuits

### DIFF
--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -202,7 +202,7 @@ def _get_enumeration_names(nodes_path, population_name):
 def _build_forced_library_map(nodes_path, population_names):
     """Build a forced_library_map for populations originating from a single nodes file.
 
-    Reads the categorical property names from the first population in the source
+    Reads the categorical property names from the unique population in the source
     file and maps them to all given population names.
 
     Args:
@@ -213,7 +213,7 @@ def _build_forced_library_map(nodes_path, population_names):
         dict: population_name -> set of property names to force as categorical.
     """
     storage = libsonata.NodeStorage(str(nodes_path))
-    src_pop_name = next(iter(storage.population_names))
+    src_pop_name = _get_unique_population(storage.population_names)
     src_enumeration_names = _get_enumeration_names(nodes_path, src_pop_name)
     return {pop_name: src_enumeration_names for pop_name in population_names}
 

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -1333,7 +1333,9 @@ def split_subcircuit(
         snap_pop = circuit.nodes[pop_name]
         forced_library_map[pop_name] = _get_enumeration_names(snap_pop.h5_filepath, pop_name)
 
-    new_node_files = _write_nodes(output, split_populations, node_pop_to_paths, forced_library=forced_library_map)
+    new_node_files = _write_nodes(
+        output, split_populations, node_pop_to_paths, forced_library=forced_library_map
+    )
 
     # Write biophysical + virtual edges together (they share edge_mappings for neuroglial)
     bio_virt_edge_configs = bio_edge_configs + virt_edge_configs

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -181,11 +181,55 @@ def _drop_column_with_warning(df: pd.DataFrame, column: str, population_name: st
     return df.drop(columns=[column])
 
 
-def _save_sonata_nodes(nodes_path, df, population_name):
+def _get_enumeration_names(nodes_path, population_name):
+    """Return the set of property names stored as @library (categorical) in a nodes file.
+
+    Uses libsonata to inspect the node population and return which properties
+    are stored as enumerations (i.e. categorical / @library).
+
+    Args:
+        nodes_path: Path to the source SONATA nodes HDF5 file.
+        population_name: Name of the node population to inspect.
+
+    Returns:
+        set of str: Property names that are stored as enumerations.
+    """
+    storage = libsonata.NodeStorage(str(nodes_path))
+    pop = storage.open_population(population_name)
+    return set(pop.enumeration_names)
+
+
+def _build_forced_library_map(nodes_path, population_names):
+    """Build a forced_library_map for populations originating from a single nodes file.
+
+    Reads the categorical property names from the first population in the source
+    file and maps them to all given population names.
+
+    Args:
+        nodes_path: Path to the source SONATA nodes HDF5 file.
+        population_names: Iterable of new population names that will be written.
+
+    Returns:
+        dict: population_name -> set of property names to force as categorical.
+    """
+    storage = libsonata.NodeStorage(str(nodes_path))
+    src_pop_name = next(iter(storage.population_names))
+    src_enumeration_names = _get_enumeration_names(nodes_path, src_pop_name)
+    return {pop_name: src_enumeration_names for pop_name in population_names}
+
+
+def _save_sonata_nodes(nodes_path, df, population_name, forced_library=None):
     """Save a dataframe of nodes (0-based IDs) to sonata file.
 
     Note: using voxcell >= 2.7.1 to load the dataframe and save the result to sonata,
     CellCollection will save the orientation using the default format (quaternions).
+
+    Args:
+        nodes_path: Path where the output SONATA nodes file will be written.
+        df: DataFrame of node properties (0-based index).
+        population_name: Name of the node population.
+        forced_library: Iterable of property names to force as categorical
+            (@library). If None, voxcell uses its default heuristic.
     """
     Path(nodes_path).parent.mkdir(parents=True, exist_ok=True)
     df = df.reset_index(drop=True)
@@ -193,7 +237,7 @@ def _save_sonata_nodes(nodes_path, df, population_name):
     df.index += 1
     cell_collection = voxcell.CellCollection.from_dataframe(df)
     cell_collection.population_name = population_name
-    cell_collection.save_sonata(str(nodes_path), mode="a")
+    cell_collection.save_sonata(str(nodes_path), mode="a", forced_library=forced_library or None)
     # restore the original index
     df.index -= 1
     L.debug("Wrote %s nodes to %s", len(df), nodes_path)
@@ -598,23 +642,33 @@ def _write_edges(
             _check_all_edges_used(h5in, written_edges)
 
 
-def _write_nodes(output, split_nodes, population_to_path=None):
+def _write_nodes(output, split_nodes, population_to_path=None, forced_library_map=None):
     """create all new node populations in separate files
 
     Args:
         output(str): base directory to write node files
         split_nodes(dict): new_population_name -> df
         population_to_path(dict): population_name -> output path
+        forced_library_map(dict): population_name -> iterable of property names
+            to force as categorical (@library). If None or missing key, voxcell
+            uses its default heuristic.
     """
     if population_to_path is None:
         population_to_path = {}
+    if forced_library_map is None:
+        forced_library_map = {}
 
     ret = {}
     for new_population, df in split_nodes.items():
         nodes_path = Path(output) / population_to_path.get(
             new_population, _get_node_file_name(new_population)
         )
-        ret[new_population] = _save_sonata_nodes(nodes_path, df, population_name=new_population)
+        ret[new_population] = _save_sonata_nodes(
+            nodes_path,
+            df,
+            population_name=new_population,
+            forced_library=forced_library_map.get(new_population),
+        )
 
     return ret
 
@@ -690,7 +744,12 @@ def split_population(output, attribute, nodes_path, edges_path):
 
     """
     split_populations = _split_population_by_attribute(nodes_path, attribute)
-    _write_nodes(output, split_populations)
+
+    # Discover which properties are categorical in the source file and preserve
+    # that storage format in all resulting sub-populations.
+    forced_library_map = _build_forced_library_map(nodes_path, split_populations)
+
+    _write_nodes(output, split_populations, forced_library_map=forced_library_map)
 
     id_mapping = IdMapping()
     for pop_name, df in split_populations.items():
@@ -723,7 +782,10 @@ def simple_split_subcircuit(output, node_set_name, node_set_path, nodes_path, ed
     """
     split_populations = _split_population_by_node_set(nodes_path, node_set_name, node_set_path)
 
-    _write_nodes(output, split_populations)
+    # Preserve categorical storage from the source file
+    forced_library_map = _build_forced_library_map(nodes_path, split_populations)
+
+    _write_nodes(output, split_populations, forced_library_map=forced_library_map)
 
     id_mapping = IdMapping()
     for pop_name, df in split_populations.items():
@@ -1273,7 +1335,16 @@ def split_subcircuit(
         )
 
     # --- WRITE phase ---
-    new_node_files = _write_nodes(output, split_populations, node_pop_to_paths)
+
+    # Build forced_library_map: for each population being written, discover which
+    # properties were stored as categorical (@library) in the parent circuit so that
+    # the same storage format is preserved in the subcircuit.
+    forced_library_map = {}
+    for pop_name in split_populations:
+        snap_pop = circuit.nodes[pop_name]
+        forced_library_map[pop_name] = _get_enumeration_names(snap_pop.h5_filepath, pop_name)
+
+    new_node_files = _write_nodes(output, split_populations, node_pop_to_paths, forced_library_map)
 
     # Write biophysical + virtual edges together (they share edge_mappings for neuroglial)
     bio_virt_edge_configs = bio_edge_configs + virt_edge_configs
@@ -1317,7 +1388,12 @@ def split_subcircuit(
         df = circuit.nodes[population_name].get(ids)
         df = _drop_column_with_warning(df, "model_template", population_name)
         nodes_path = Path(output) / population_name / "nodes.h5"
-        new_node_files[population_name] = _save_sonata_nodes(nodes_path, df, population_name)
+        forced_library = _get_enumeration_names(
+            circuit.nodes[population_name].h5_filepath, population_name
+        )
+        new_node_files[population_name] = _save_sonata_nodes(
+            nodes_path, df, population_name, forced_library=forced_library
+        )
 
     # Write existing external nodes (filtered from parent, skip if biophysical gather handles it)
     for population_name, ids in existing_ext_node_ids.items():
@@ -1326,19 +1402,28 @@ def split_subcircuit(
         df = circuit.nodes[population_name].get(ids)
         df = _drop_column_with_warning(df, "model_template", population_name)
         nodes_path = Path(output) / population_name / "nodes.h5"
-        new_node_files[population_name] = _save_sonata_nodes(nodes_path, df, population_name)
+        forced_library = _get_enumeration_names(
+            circuit.nodes[population_name].h5_filepath, population_name
+        )
+        new_node_files[population_name] = _save_sonata_nodes(
+            nodes_path, df, population_name, forced_library=forced_library
+        )
 
     # Write newly-externalized nodes
     for population_name, orig_population_name in ext_nodes.items():
         frames = []
+        forced_library = set()
         for source_pop, df in id_mapping.data[population_name].items():
             source_ids = df.index.to_numpy()
             frames.append(circuit.nodes[source_pop].get(source_ids))
+            forced_library |= _get_enumeration_names(
+                circuit.nodes[source_pop].h5_filepath, source_pop
+            )
         combined_df = pd.concat(frames)
         combined_df = _drop_column_with_warning(combined_df, "model_template", population_name)
         nodes_path = Path(output) / population_name / "nodes.h5"
         new_node_files[population_name] = _save_sonata_nodes(
-            nodes_path, combined_df, population_name
+            nodes_path, combined_df, population_name, forced_library=forced_library
         )
 
     provenance = circuit.config.get("components", {}).get("provenance", {})

--- a/brainbuilder/utils/sonata/split_population.py
+++ b/brainbuilder/utils/sonata/split_population.py
@@ -199,25 +199,6 @@ def _get_enumeration_names(nodes_path, population_name):
     return set(pop.enumeration_names)
 
 
-def _build_forced_library_map(nodes_path, population_names):
-    """Build a forced_library_map for populations originating from a single nodes file.
-
-    Reads the categorical property names from the unique population in the source
-    file and maps them to all given population names.
-
-    Args:
-        nodes_path: Path to the source SONATA nodes HDF5 file.
-        population_names: Iterable of new population names that will be written.
-
-    Returns:
-        dict: population_name -> set of property names to force as categorical.
-    """
-    storage = libsonata.NodeStorage(str(nodes_path))
-    src_pop_name = _get_unique_population(storage.population_names)
-    src_enumeration_names = _get_enumeration_names(nodes_path, src_pop_name)
-    return {pop_name: src_enumeration_names for pop_name in population_names}
-
-
 def _save_sonata_nodes(nodes_path, df, population_name, forced_library=None):
     """Save a dataframe of nodes (0-based IDs) to sonata file.
 
@@ -642,21 +623,26 @@ def _write_edges(
             _check_all_edges_used(h5in, written_edges)
 
 
-def _write_nodes(output, split_nodes, population_to_path=None, forced_library_map=None):
+def _write_nodes(output, split_nodes, population_to_path=None, forced_library=None):
     """create all new node populations in separate files
 
     Args:
         output(str): base directory to write node files
         split_nodes(dict): new_population_name -> df
         population_to_path(dict): population_name -> output path
-        forced_library_map(dict): population_name -> iterable of property names
-            to force as categorical (@library). If None or missing key, voxcell
-            uses its default heuristic.
+        forced_library(dict | set | None): If a dict, maps population_name ->
+            iterable of property names to force as categorical. If a set (or list),
+            the same property names are used for all populations.
+            If None, voxcell uses its default heuristic.
     """
     if population_to_path is None:
         population_to_path = {}
-    if forced_library_map is None:
-        forced_library_map = {}
+
+    # Normalize: if forced_library is not a dict, treat it as a shared set for all populations
+    if isinstance(forced_library, dict):
+        forced_library_map = forced_library
+    else:
+        forced_library_map = {pop: forced_library for pop in split_nodes}
 
     ret = {}
     for new_population, df in split_nodes.items():
@@ -745,11 +731,12 @@ def split_population(output, attribute, nodes_path, edges_path):
     """
     split_populations = _split_population_by_attribute(nodes_path, attribute)
 
-    # Discover which properties are categorical in the source file and preserve
-    # that storage format in all resulting sub-populations.
-    forced_library_map = _build_forced_library_map(nodes_path, split_populations)
+    # Preserve categorical properties from the source file in all resulting sub-populations.
+    storage = libsonata.NodeStorage(str(nodes_path))
+    src_pop_name = _get_unique_population(storage.population_names)
+    forced_library = _get_enumeration_names(nodes_path, src_pop_name)
 
-    _write_nodes(output, split_populations, forced_library_map=forced_library_map)
+    _write_nodes(output, split_populations, forced_library=forced_library)
 
     id_mapping = IdMapping()
     for pop_name, df in split_populations.items():
@@ -783,9 +770,11 @@ def simple_split_subcircuit(output, node_set_name, node_set_path, nodes_path, ed
     split_populations = _split_population_by_node_set(nodes_path, node_set_name, node_set_path)
 
     # Preserve categorical storage from the source file
-    forced_library_map = _build_forced_library_map(nodes_path, split_populations)
+    storage = libsonata.NodeStorage(str(nodes_path))
+    src_pop_name = _get_unique_population(storage.population_names)
+    forced_library = _get_enumeration_names(nodes_path, src_pop_name)
 
-    _write_nodes(output, split_populations, forced_library_map=forced_library_map)
+    _write_nodes(output, split_populations, forced_library=forced_library)
 
     id_mapping = IdMapping()
     for pop_name, df in split_populations.items():
@@ -1344,7 +1333,7 @@ def split_subcircuit(
         snap_pop = circuit.nodes[pop_name]
         forced_library_map[pop_name] = _get_enumeration_names(snap_pop.h5_filepath, pop_name)
 
-    new_node_files = _write_nodes(output, split_populations, node_pop_to_paths, forced_library_map)
+    new_node_files = _write_nodes(output, split_populations, node_pop_to_paths, forced_library=forced_library_map)
 
     # Write biophysical + virtual edges together (they share edge_mappings for neuroglial)
     bio_virt_edge_configs = bio_edge_configs + virt_edge_configs

--- a/tests/unit/test_sonata/test_split_population.py
+++ b/tests/unit/test_sonata/test_split_population.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import bluepysnap
 import h5py
+import libsonata
 import numpy as np
 import pandas as pd
 import pytest
@@ -1556,3 +1557,250 @@ def test_external_populations_preserve_nonstandard_synapse_type(tmp_path):
                 f"Sub-subcircuit: Population '{pop_name}' has type '{pop_config.get('type')}' "
                 f"but expected '{custom_type}'"
             )
+
+
+def test_save_sonata_nodes_preserves_forced_library(tmp_path):
+    """Properties listed in forced_library remain categorical; others stay non-categorical."""
+    import voxcell
+
+    # Create a source nodes file where 'mtype' is categorical (@library) but 'label' is not.
+    # Heuristic: #unique < 0.5 * #total
+    #   mtype: 2 unique / 6 total -> 2 < 3 -> categorical
+    #   label: 5 unique / 6 total -> 5 < 3 -> NOT categorical
+    df_source = pd.DataFrame({
+        "mtype": ["a", "b", "a", "b", "a", "b"],
+        "label": ["x1", "x2", "x3", "x4", "x5", "x1"],
+    })
+    df_source.index += 1
+    cc = voxcell.CellCollection.from_dataframe(df_source)
+    cc.population_name = "pop"
+    src_path = tmp_path / "source_nodes.h5"
+    cc.save_sonata(str(src_path))
+
+    # Verify the source has mtype in @library but not label
+    with h5py.File(src_path, "r") as h5:
+        assert "@library" in h5["nodes/pop/0"]
+        assert "mtype" in h5["nodes/pop/0/@library"]
+        assert "label" not in h5["nodes/pop/0/@library"]
+
+    # Now extract a small subset (2 nodes). Without forced_library, voxcell's heuristic
+    # would NOT create @library for mtype (2 unique / 2 total -> 2 < 1 is False).
+    forced_library = split_population._get_enumeration_names(src_path, "pop")
+    assert forced_library == {"mtype"}
+
+    df_subset = pd.DataFrame({
+        "mtype": ["a", "b"],
+        "label": ["x1", "x2"],
+    })
+    output_path = tmp_path / "output" / "nodes.h5"
+    split_population._save_sonata_nodes(
+        output_path, df_subset, population_name="pop", forced_library=forced_library
+    )
+
+    # Verify: mtype is still categorical, label is still non-categorical
+    with h5py.File(output_path, "r") as h5:
+        assert "@library" in h5["nodes/pop/0"]
+        assert "mtype" in h5["nodes/pop/0/@library"]
+        assert "label" not in h5["nodes/pop/0/@library"]
+        # Verify the actual values are correct
+        mtypes = sonata_utils.get_property(h5["nodes/pop/0"], h5["nodes/pop/0/mtype"][:], "mtype")
+        assert set(mtypes) == {b"a", b"b"}
+        labels = h5["nodes/pop/0/label"][:]
+        assert set(labels) == {b"x1", b"x2"}
+
+
+
+def _create_categorical_circuit(path):
+    """Create a minimal circuit where nodes have categorical properties.
+
+    Population:
+        A: 6 biophysical nodes (IDs 0-5)
+            - mtype: ["a","b","a","b","a","b"] -> 2 unique / 6 total -> categorical
+            - label: 6 unique values -> NOT categorical
+        V1: 4 virtual nodes (IDs 0-3)
+            - model_type: ["virtual"] * 4 -> 1 unique / 4 total -> categorical
+
+    Edges:
+        A (intra): A nodes {2,3,4,5} target A nodes {0,1,0,1} (creates externals)
+        V1->A: V1 nodes {0,1} target A nodes {0,1}
+
+    Node set:
+        "subset": selects A nodes [0, 1] (2 nodes).
+        With 2 nodes and 2 unique mtype values, the heuristic (2 < 1) would NOT
+        make mtype categorical. This is where forced_library is essential.
+    """
+    import voxcell
+
+    path.mkdir(parents=True, exist_ok=True)
+    nodes_dir = path / "networks" / "nodes"
+    edges_dir = path / "networks" / "edges"
+    nodes_dir.mkdir(parents=True)
+    edges_dir.mkdir(parents=True)
+
+    # --- Biophysical nodes ---
+    df = pd.DataFrame({
+        "mtype": ["a", "b", "a", "b", "a", "b"],
+        "label": [f"A_{i}" for i in range(6)],
+        "model_type": ["biophysical"] * 6,
+    })
+    df.index += 1
+    cc = voxcell.CellCollection.from_dataframe(df)
+    cc.population_name = "A"
+    cc.save_sonata(str(nodes_dir / "nodes.h5"))
+
+    # --- Virtual nodes ---
+    df_v = pd.DataFrame({"model_type": ["virtual"] * 4})
+    df_v.index += 1
+    cc_v = voxcell.CellCollection.from_dataframe(df_v)
+    cc_v.population_name = "V1"
+    cc_v.save_sonata(str(nodes_dir / "virtual_nodes_V1.h5"))
+
+    # --- Verify source has @library set up correctly ---
+    with h5py.File(nodes_dir / "nodes.h5", "r") as h5:
+        assert "mtype" in h5["nodes/A/0/@library"]
+        assert "label" not in h5["nodes/A/0/@library"]
+
+    # --- Edges ---
+    # A intra-population: nodes {2,3,4,5} target nodes {0,1,0,1}
+    # Ensures nodes 2-5 project into subset {0,1} and get externalized.
+    with h5py.File(edges_dir / "edges.h5", "w") as h5:
+        ds = h5.create_dataset(
+            "/edges/A/source_node_id", data=np.array([2, 3, 4, 5], dtype=int)
+        )
+        ds.attrs["node_population"] = "A"
+        ds = h5.create_dataset(
+            "/edges/A/target_node_id", data=np.array([0, 1, 0, 1], dtype=int)
+        )
+        ds.attrs["node_population"] = "A"
+        h5.create_dataset("/edges/A/0/delay", data=[0.5] * 4)
+        h5.create_dataset("/edges/A/edge_type_id", data=[-1] * 4)
+
+    libsonata.EdgePopulation.write_indices(
+        str(edges_dir / "edges.h5"), "A", source_node_count=6, target_node_count=6
+    )
+
+    # V1->A: nodes {0,1} target A nodes {0,1} (both in subset)
+    with h5py.File(edges_dir / "virtual_edges_V1.h5", "w") as h5:
+        ds = h5.create_dataset("/edges/V1__A/source_node_id", data=np.array([0, 1], dtype=int))
+        ds.attrs["node_population"] = "V1"
+        ds = h5.create_dataset("/edges/V1__A/target_node_id", data=np.array([0, 1], dtype=int))
+        ds.attrs["node_population"] = "A"
+        h5.create_dataset("/edges/V1__A/0/delay", data=[0.5] * 2)
+        h5.create_dataset("/edges/V1__A/edge_type_id", data=[-1] * 2)
+
+    libsonata.EdgePopulation.write_indices(
+        str(edges_dir / "virtual_edges_V1.h5"), "V1__A",
+        source_node_count=4, target_node_count=6
+    )
+
+    # --- Node set ---
+    node_sets = {
+        "subset": {"population": "A", "node_id": [0, 1]},
+    }
+    dump_json(path / "node_sets.json", node_sets)
+
+    # --- Circuit config ---
+    config = {
+        "version": 2,
+        "manifest": {
+            "$BASE_DIR": ".",
+            "$NETWORK_NODES_DIR": "$BASE_DIR/networks/nodes",
+            "$NETWORK_EDGES_DIR": "$BASE_DIR/networks/edges",
+        },
+        "components": {
+            "morphologies_dir": "$BASE_DIR/morphologies",
+            "biophysical_neuron_models_dir": "$BASE_DIR/emodels",
+        },
+        "node_sets_file": "$BASE_DIR/node_sets.json",
+        "networks": {
+            "nodes": [
+                {
+                    "nodes_file": "$NETWORK_NODES_DIR/nodes.h5",
+                    "populations": {
+                        "A": {"type": "biophysical"},
+                    },
+                },
+                {
+                    "nodes_file": "$NETWORK_NODES_DIR/virtual_nodes_V1.h5",
+                    "populations": {
+                        "V1": {"type": "virtual"},
+                    },
+                },
+            ],
+            "edges": [
+                {
+                    "edges_file": "$NETWORK_EDGES_DIR/edges.h5",
+                    "populations": {
+                        "A": {"type": "chemical"},
+                    },
+                },
+                {
+                    "edges_file": "$NETWORK_EDGES_DIR/virtual_edges_V1.h5",
+                    "populations": {
+                        "V1__A": {"type": "chemical"},
+                    },
+                },
+            ],
+        },
+    }
+    dump_json(path / "circuit_config.json", config)
+    return path / "circuit_config.json"
+
+
+def test_split_subcircuit_preserves_categorical_biophysical(tmp_path):
+    """Biophysical: mtype stays in @library even when subset is too small for the heuristic."""
+    circuit_config = _create_categorical_circuit(tmp_path / "fixture")
+
+    output = tmp_path / "output"
+    split_population.split_subcircuit(
+        output, "subset", str(circuit_config), do_virtual=False, create_external=False
+    )
+
+    # Extracted 2 nodes. mtype has 2 unique / 2 total -> heuristic (2 < 1) would NOT make it
+    # categorical. This verifies forced_library is working.
+    with h5py.File(output / "A" / "nodes.h5", "r") as h5:
+        group = h5["nodes/A/0"]
+        assert "@library" in group, "A: @library should exist"
+        assert "mtype" in group["@library"], "A: mtype should be in @library"
+        assert "label" not in group["@library"], "A: label should NOT be in @library"
+
+
+def test_split_subcircuit_preserves_categorical_virtual(tmp_path):
+    """Virtual: model_type stays in @library after extraction."""
+    circuit_config = _create_categorical_circuit(tmp_path / "fixture")
+
+    output = tmp_path / "output"
+    split_population.split_subcircuit(
+        output, "subset", str(circuit_config), do_virtual=True, create_external=False
+    )
+
+    # V1 nodes {0,1} target A subset {0,1}, so both V1 nodes are extracted.
+    # model_type has 1 unique / 2 total -> heuristic (1 < 1) would NOT make it categorical.
+    # This verifies forced_library is working for virtual populations.
+    v1_path = output / "V1" / "nodes.h5"
+    assert v1_path.exists(), "V1 nodes should be extracted"
+    with h5py.File(v1_path, "r") as h5:
+        group = h5["nodes/V1/0"]
+        assert "@library" in group, "V1: @library should exist"
+        assert "model_type" in group["@library"], "V1: model_type should be in @library"
+
+
+def test_split_subcircuit_preserves_categorical_external(tmp_path):
+    """External: mtype stays in @library for externalized nodes."""
+    circuit_config = _create_categorical_circuit(tmp_path / "fixture")
+
+    output = tmp_path / "output"
+    split_population.split_subcircuit(
+        output, "subset", str(circuit_config), do_virtual=False, create_external=True
+    )
+
+    # A nodes {2,3,4,5} project into subset {0,1} but are not in it -> externalized.
+    # mtype has 2 unique / 4 total -> heuristic (2 < 2) would NOT make it categorical.
+    # This verifies forced_library is working for externalized populations.
+    ext_path = output / "external_A" / "nodes.h5"
+    assert ext_path.exists(), "external_A should be created"
+    with h5py.File(ext_path, "r") as h5:
+        group = h5["nodes/external_A/0"]
+        assert "@library" in group, "external_A: @library should exist"
+        assert "mtype" in group["@library"], "external_A: mtype should be in @library"
+        assert "label" not in group["@library"], "external_A: label should NOT be in @library"


### PR DESCRIPTION
- Node properties stored as `@library` in the parent circuit could lose that format after splitting because voxcell's heuristic (#unique < 0.5 * #total) may not trigger for smaller populations
- Fix: read categorical property names from the source via libsonata's `enumeration_names` and pass them to `save_sonata(forced_library=...)`
- Applies to all split paths: biophysical, virtual, and externalized nodes
- Added tests where the heuristic alone would fail, verifying `forced_library` is effective

Related issue: https://github.com/openbraininstitute/prod-build-circuit/issues/48